### PR TITLE
fix: Update transaction library for latest alphanet tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "radix-engine"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "colored",
  "hex",
@@ -1213,7 +1213,7 @@ checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 [[package]]
 name = "sbor"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "hex",
  "sbor-derive",
@@ -1223,7 +1223,7 @@ dependencies = [
 [[package]]
 name = "sbor-derive"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1240,7 +1240,7 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 [[package]]
 name = "scrypto"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "bech32",
  "forward_ref",
@@ -1260,7 +1260,7 @@ dependencies = [
 [[package]]
 name = "scrypto-abi"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "sbor",
  "serde",
@@ -1269,7 +1269,7 @@ dependencies = [
 [[package]]
 name = "scrypto-derive"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1516,7 +1516,7 @@ dependencies = [
 [[package]]
 name = "transaction"
 version = "0.6.0"
-source = "git+https://github.com/radixdlt/radixdlt-scrypto?branch=alphanet#e7c531a8002ffc10a75a40bfab266fc8264e5b2e"
+source = "git+https://github.com/radixdlt/radixdlt-scrypto?tag=alphanet-259457#2594576c6dc470e32a7793159d2a9dd480ee34c6"
 dependencies = [
  "clap",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ serde = { version = "1.0.144", features = ["serde_derive"] }
 serde_json = { version = "1.0.85" }
 serde_with = { version = "2.0.0", features = ["hex"] }
 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", branch = "alphanet" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", branch = "alphanet", features = ["serde"] }
-transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", branch = "alphanet", features = ["serde"] }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", branch = "alphanet" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "alphanet-259457" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "alphanet-259457", features = ["serde"] }
+transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "alphanet-259457", features = ["serde"] }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "alphanet-259457" }
 
 wee_alloc = { version =  "0.4.5" }
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -5,7 +5,7 @@ use std::convert::TryInto;
 use radix_engine::constants::DEFAULT_MAX_COST_UNIT_LIMIT;
 use scrypto::address::Bech32Decoder;
 use transaction::manifest::ast::Instruction as AstInstruction;
-use transaction::validation::ValidationConfig;
+use transaction::validation::{ValidationConfig, NotarizedTransactionValidator, TransactionValidator};
 
 use crate::address::Bech32Manager;
 use crate::error::Error;
@@ -67,10 +67,11 @@ pub fn validate_transaction_intent(intent: &TransactionIntent) -> Result<(), Err
     let validation_config: ValidationConfig = new_validation_config(network_id, end_epoch);
     let transaction_intent: transaction::model::TransactionIntent = intent.clone().try_into()?;
 
-    transaction::validation::TransactionValidator::validate_intent(
+    let transaction_validator = NotarizedTransactionValidator::new(validation_config);
+
+    transaction_validator.validate_intent(
         &transaction_intent,
         &transaction::validation::TestIntentHashManager::new(),
-        &validation_config,
     )?;
     Ok(())
 }
@@ -105,10 +106,10 @@ pub fn validate_notarized_transaction(
     };
 
     let validation_config: ValidationConfig = new_validation_config(network_id, end_epoch);
-    transaction::validation::TransactionValidator::validate(
+    let transaction_validator = NotarizedTransactionValidator::new(validation_config);
+    transaction_validator.validate(
         notarized_transaction,
         &transaction::validation::TestIntentHashManager::new(),
-        &validation_config,
     )?;
     Ok(())
 }


### PR DESCRIPTION
I've also made it so that the upstream pulled in is fixed to a particular tag - to avoid issues with anyone using this as a dependency, and pulling in new versions of the upstream (as Theo discovered!)