### PR TITLE
Add two missing error kinds to OpenAPI spec

### DIFF
--- a/spec/transaction-api-spec.yaml
+++ b/spec/transaction-api-spec.yaml
@@ -1710,6 +1710,8 @@ components:
         - RequestResponseConversionError
         - UnrecognizedCompiledIntentFormat
         - TransactionValidationError
+        - ExtractAbiError
+        - NetworkMismatchError
 
     ErrorResponse:
       oneOf:


### PR DESCRIPTION
Add two missing error kinds:
* ExtractAbiError
* NetworkMismatchError