### PR TITLE
Update to develop-a2cc02494

### DIFF
--- a/cli-json-interface/Cargo.toml
+++ b/cli-json-interface/Cargo.toml
@@ -14,13 +14,13 @@ radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 serde = "1.0.152"
 serde_json = "1.0.93"
 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "utils" }
-native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "transaction" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "utils" }
+native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "transaction" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
 hex = "0.4.3"
 
 [[bin]]

--- a/radix-engine-toolkit/Cargo.toml
+++ b/radix-engine-toolkit/Cargo.toml
@@ -16,13 +16,13 @@ schemars = { version = "0.8.11", features = ["preserve_order"] }
 toolkit-derive = { path = "../toolkit-derive" }
 
 # Scrypto dependencies required for the core-toolkit
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "utils" }
-native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "transaction" }
-radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", optional = true }
-radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "utils" }
+native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "transaction" }
+radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", optional = true }
+radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
 
 # Hex is used for the internal hex encoding and decoding of values - serde_with::Hex is used for the
 # hex representation during serialization.

--- a/radix-engine-toolkit/src/example/instruction.rs
+++ b/radix-engine-toolkit/src/example/instruction.rs
@@ -715,7 +715,7 @@ pub fn publish_package() -> Instruction {
     instruction
 }
 
-pub fn drop_proof() -> Instruction {
+pub fn burn_resource() -> Instruction {
     let instruction = Instruction::BurnResource {
         bucket: ManifestAstValue::Bucket {
             identifier: BucketId(TransientIdentifier::String {
@@ -733,8 +733,14 @@ pub fn drop_all_proofs() -> Instruction {
     instruction
 }
 
-pub fn burn_resource() -> Instruction {
-    let instruction = Instruction::DropAllProofs;
+pub fn drop_proof() -> Instruction {
+    let instruction = Instruction::DropProof {
+        proof: ManifestAstValue::Proof {
+            identifier: ProofId(TransientIdentifier::String {
+                value: "proof".into(),
+            }),
+        },
+    };
     check_instruction(&instruction);
     instruction
 }
@@ -1018,6 +1024,34 @@ pub fn create_non_fungible_resource() -> Instruction {
             variant: EnumDiscriminator::U8 { discriminator: 0 },
             fields: None,
         },
+        schema: ManifestAstValue::Tuple {
+            elements: vec![
+                ManifestAstValue::Tuple {
+                    elements: vec![
+                        ManifestAstValue::Array {
+                            element_kind: ManifestAstValueKind::Enum,
+                            elements: vec![],
+                        },
+                        ManifestAstValue::Array {
+                            element_kind: ManifestAstValueKind::Tuple,
+                            elements: vec![],
+                        },
+                        ManifestAstValue::Array {
+                            element_kind: ManifestAstValueKind::Enum,
+                            elements: vec![],
+                        },
+                    ],
+                },
+                ManifestAstValue::Enum {
+                    variant: EnumDiscriminator::U8 { discriminator: 0 },
+                    fields: Some(vec![ManifestAstValue::U8 { value: 64 }]),
+                },
+                ManifestAstValue::Array {
+                    element_kind: ManifestAstValueKind::String,
+                    elements: vec![],
+                },
+            ],
+        },
         metadata: ManifestAstValue::Map {
             key_value_kind: ManifestAstValueKind::String,
             value_value_kind: ManifestAstValueKind::String,
@@ -1136,6 +1170,12 @@ pub fn create_validator() -> Instruction {
             fields: None,
         },
     };
+    check_instruction(&instruction);
+    instruction
+}
+
+pub fn clear_signature_proofs() -> Instruction {
+    let instruction = Instruction::ClearSignatureProofs;
     check_instruction(&instruction);
     instruction
 }

--- a/radix-engine-toolkit/src/example/value/scrypto_sbor_value.rs
+++ b/radix-engine-toolkit/src/example/value/scrypto_sbor_value.rs
@@ -23,6 +23,7 @@ use scrypto::prelude::{
 };
 
 use crate::model::address::*;
+use crate::model::engine_identifier::NodeIdentifier;
 use crate::model::value::scrypto_sbor::{ScryptoSborValue, ScryptoSborValueKind};
 
 pub fn value() -> ScryptoSborValue {
@@ -244,5 +245,11 @@ pub fn non_fungible_local_id4() -> ScryptoSborValue {
         value: NonFungibleLocalId::Bytes(
             BytesNonFungibleLocalId::new(vec![0x01, 0x02, 0x03, 0x04]).unwrap(),
         ),
+    }
+}
+
+pub fn reference() -> ScryptoSborValue {
+    ScryptoSborValue::Reference {
+        value: NodeIdentifier([0; OBJECT_ID_LENGTH]),
     }
 }

--- a/radix-engine-toolkit/src/model/engine_identifier/node_identifier.rs
+++ b/radix-engine-toolkit/src/model/engine_identifier/node_identifier.rs
@@ -30,10 +30,10 @@ use crate::utils::checked_copy_u8_slice;
 
 #[serializable]
 /// Represents a Radix Engine persistent node identifier which is 36 bytes long and serialized as a
-/// hexadecimal string of length 72 (since hex encoding doubles the number of bytes needed.)
-#[derive(PartialEq, PartialOrd, Eq, Ord)]
+/// hexadecimal string of length 31 (since hex encoding doubles the number of bytes needed.)
+#[derive(PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct NodeIdentifier(
-    #[schemars(length(equal = 72))]
+    #[schemars(length(equal = 31))]
     #[schemars(regex(pattern = "[0-9a-fA-F]+"))]
     #[schemars(with = "String")]
     #[serde_as(as = "serde_with::hex::Hex")]

--- a/radix-engine-toolkit/src/model/value/scrypto_sbor/bridge.rs
+++ b/radix-engine-toolkit/src/model/value/scrypto_sbor/bridge.rs
@@ -18,6 +18,7 @@
 use super::model::*;
 use crate::error::Result;
 use crate::model::address::*;
+use crate::model::engine_identifier::NodeIdentifier;
 
 use scrypto::prelude::{
     ScryptoCustomValue, ScryptoCustomValueKind, ScryptoValue, ScryptoValueKind,
@@ -62,6 +63,9 @@ impl From<ScryptoValueKind> for ScryptoSborValueKind {
                 ScryptoSborValueKind::NonFungibleLocalId
             }
             ScryptoValueKind::Custom(ScryptoCustomValueKind::Own) => ScryptoSborValueKind::Own,
+            ScryptoValueKind::Custom(ScryptoCustomValueKind::Reference) => {
+                ScryptoSborValueKind::Reference
+            }
         }
     }
 }
@@ -103,6 +107,9 @@ impl From<ScryptoSborValueKind> for ScryptoValueKind {
                 ScryptoValueKind::Custom(ScryptoCustomValueKind::NonFungibleLocalId)
             }
             ScryptoSborValueKind::Own => ScryptoValueKind::Custom(ScryptoCustomValueKind::Own),
+            ScryptoSborValueKind::Reference => {
+                ScryptoValueKind::Custom(ScryptoCustomValueKind::Reference)
+            }
         }
     }
 }
@@ -188,6 +195,11 @@ impl ScryptoSborValue {
 
             Self::Own { value } => ScryptoValue::Custom {
                 value: ScryptoCustomValue::Own(*value),
+            },
+            Self::Reference { value } => ScryptoValue::Custom {
+                value: ScryptoCustomValue::InternalRef(
+                    radix_engine_common::data::scrypto::model::InternalRef(value.0),
+                ),
             },
         };
         Ok(value)
@@ -308,6 +320,11 @@ impl ScryptoSborValue {
             ScryptoValue::Custom {
                 value: ScryptoCustomValue::Own(value),
             } => Self::Own { value: *value },
+            ScryptoValue::Custom {
+                value: ScryptoCustomValue::InternalRef(value),
+            } => Self::Reference {
+                value: NodeIdentifier(value.0),
+            },
         }
     }
 }

--- a/radix-engine-toolkit/src/model/value/scrypto_sbor/model.rs
+++ b/radix-engine-toolkit/src/model/value/scrypto_sbor/model.rs
@@ -17,6 +17,7 @@
 
 use crate::define_kind_enum;
 use crate::model::address::EntityAddress;
+use crate::model::engine_identifier::NodeIdentifier;
 
 use scrypto::prelude::{Decimal, NonFungibleLocalId, PreciseDecimal};
 use scrypto::runtime::Own;
@@ -248,5 +249,11 @@ define_kind_enum! {
             #[serde_as(as = "serde_with::TryFromInto<crate::model::address::NonFungibleLocalId>")]
             value: NonFungibleLocalId,
         },
+
+        /// Represents a reference to some RENode.
+        #[schemars(example = "crate::example::value::scrypto_sbor_value::reference")]
+        Reference {
+            value: NodeIdentifier
+        }
     }
 }

--- a/radix-engine-toolkit/src/visitor/instruction/instruction_visitor.rs
+++ b/radix-engine-toolkit/src/visitor/instruction/instruction_visitor.rs
@@ -201,12 +201,14 @@ define_instruction_visitor! {
 
         visit_create_non_fungible_resource(
             _id_type: &mut crate::model::value::ast::ManifestAstValue,
+            _schema: &mut crate::model::value::ast::ManifestAstValue,
             _metadata: &mut crate::model::value::ast::ManifestAstValue,
             _access_rules: &mut crate::model::value::ast::ManifestAstValue
         ),
 
         visit_create_non_fungible_resource_with_owner(
             _id_type: &mut crate::model::value::ast::ManifestAstValue,
+            _schema: &mut crate::model::value::ast::ManifestAstValue,
             _metadata: &mut crate::model::value::ast::ManifestAstValue,
             _access_rules: &mut crate::model::value::ast::ManifestAstValue,
             _initial_supply: &mut crate::model::value::ast::ManifestAstValue
@@ -237,6 +239,7 @@ define_instruction_visitor! {
 
         visit_clear_auth_zone(),
         visit_drop_all_proofs(),
+        visit_clear_signature_proofs(),
 
         post_visit()
     }
@@ -687,16 +690,19 @@ pub fn traverse_instruction(
 
         Instruction::CreateNonFungibleResource {
             id_type,
+            schema,
             metadata,
             access_rules,
         } => {
             traverse_value(id_type, value_visitors)?;
+            traverse_value(schema, value_visitors)?;
             traverse_value(metadata, value_visitors)?;
             traverse_value(access_rules, value_visitors)?;
             visit!(
                 instructions_visitors,
                 visit_create_non_fungible_resource,
                 id_type,
+                schema,
                 metadata,
                 access_rules
             )?;
@@ -704,11 +710,13 @@ pub fn traverse_instruction(
 
         Instruction::CreateNonFungibleResourceWithInitialSupply {
             id_type,
+            schema,
             metadata,
             access_rules,
             initial_supply,
         } => {
             traverse_value(id_type, value_visitors)?;
+            traverse_value(schema, value_visitors)?;
             traverse_value(metadata, value_visitors)?;
             traverse_value(access_rules, value_visitors)?;
             traverse_value(initial_supply, value_visitors)?;
@@ -716,6 +724,7 @@ pub fn traverse_instruction(
                 instructions_visitors,
                 visit_create_non_fungible_resource_with_owner,
                 id_type,
+                schema,
                 metadata,
                 access_rules,
                 initial_supply
@@ -770,6 +779,9 @@ pub fn traverse_instruction(
 
         Instruction::DropAllProofs => {
             visit!(instructions_visitors, visit_drop_all_proofs,)?;
+        }
+        Instruction::ClearSignatureProofs => {
+            visit!(instructions_visitors, visit_clear_signature_proofs,)?;
         }
         Instruction::ClearAuthZone => {
             visit!(instructions_visitors, visit_clear_auth_zone,)?;

--- a/radix-engine-toolkit/tests/common_manifests.rs
+++ b/radix-engine-toolkit/tests/common_manifests.rs
@@ -28,7 +28,7 @@ const MANIFESTS_PATH: &str = "./tests/test_vector/manifest";
 pub fn common_manifests_can_be_converted_to_parsed_manifests() {
     // Arrange
     for file_path in rtm_file_paths(MANIFESTS_PATH) {
-        let manifest_str = std::fs::read_to_string(file_path)
+        let manifest_str = std::fs::read_to_string(&file_path)
             .map(manifest_replace)
             .unwrap();
 
@@ -55,7 +55,7 @@ pub fn common_manifests_can_be_converted_to_parsed_manifests() {
 pub fn common_manifests_can_be_converted_to_parsed_and_then_back_to_string_manifests() {
     // Arrange
     for file_path in rtm_file_paths(MANIFESTS_PATH) {
-        let manifest_str = std::fs::read_to_string(file_path)
+        let manifest_str = std::fs::read_to_string(&file_path)
             .map(manifest_replace)
             .unwrap();
 
@@ -81,7 +81,6 @@ pub fn common_manifests_can_be_converted_to_parsed_and_then_back_to_string_manif
         let response = ConvertManifestHandler::fulfill(request);
 
         // Assert
-        println!("{:?}", response);
         assert!(matches!(response, Ok(..)));
     }
 }
@@ -144,7 +143,7 @@ fn manifest_replace(string: String) -> String {
             "5b4b01a4a3892ea3751793da57f072ae08eec694ddcda872239fc8239e4bcd1b",
         )
         .replace(
-            "{abi_blob_hash}",
+            "{schema_blob_hash}",
             "5b4b01a4a3892ea3751793da57f072ae08eec694ddcda872239fc8239e4bcd1b",
         )
         .replace("{initial_supply}", "12")

--- a/radix-engine-toolkit/tests/test_vector/manifest/account/multi_account_resource_transfer.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/account/multi_account_resource_transfer.rtm
@@ -12,13 +12,13 @@
 # that you are using is resim then you can safely ignore this warning.
 # ==================================================================================================
 CALL_METHOD 
-    Address("${this_account_component_address}")
+    Address("${this_account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Withdrawing 330 XRD from the account component
 CALL_METHOD 
-    Address("${this_account_component_address}")
+    Address("${this_account_component_address}") 
     "withdraw"
     Address("${xrd_resource_address}")
     Decimal("330");

--- a/radix-engine-toolkit/tests/test_vector/manifest/account/resource_transfer.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/account/resource_transfer.rtm
@@ -8,19 +8,19 @@
 # that you are using is resim then you can safely ignore this warning.
 # ==================================================================================================
 CALL_METHOD 
-    Address("${this_account_component_address}")
+    Address("${this_account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Withdrawing 100 XRD from the account component
 CALL_METHOD 
-    Address("${this_account_component_address}")
+    Address("${this_account_component_address}") 
     "withdraw"
     Address("${xrd_resource_address}")
     Decimal("100");
 
 # Depositing all of the XRD withdrawn from the account into the other account
 CALL_METHOD
-    Address("${other_account_component_address}")
+    Address("${other_account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/faucet/free_funds.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/faucet/free_funds.rtm
@@ -10,18 +10,18 @@
 # account component. However, since this example hows how to get free funds from the faucet, then 
 # we can assume that our account component probably has no funds in the first place. 
 CALL_METHOD 
-    Address("${faucet_component_address}")
+    Address("${faucet_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Calling the "free" method on the faucet component which is the method responsible for dispensing 
 # XRD from the faucet.
 CALL_METHOD 
-    Address("${faucet_component_address}")
+    Address("${faucet_component_address}") 
     "free";
 
 # Depositing all of the XRD dispensed from the faucet into our account component.
 CALL_METHOD
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/package/publish.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/package/publish.rtm
@@ -8,20 +8,20 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Publishing a new package and setting some of its royalty and access rules.
 PUBLISH_PACKAGE 
-    Blob("5b4b01a4a3892ea3751793da57f072ae08eec694ddcda872239fc8239e4bcd1b") 
-    Blob("5b4b01a4a3892ea3751793da57f072ae08eec694ddcda872239fc8239e4bcd1b") 
+    Blob("${code_blob_hash}") 
+    Blob("${schema_blob_hash}") 
     Map<String, Tuple>()       # Royalty Configuration
     Map<String, String>()      # Metadata 
     Tuple(                     # Access Rules Struct
         Map<Tuple, Enum>(       # Method auth Field
             Tuple(
-                Enum("NodeModuleId::PackageRoyalty"),
+                Enum("NodeModuleId::SELF"),
                 "set_royalty_config"
             ),
             Enum(
@@ -41,7 +41,7 @@ PUBLISH_PACKAGE
                 )
             ),
             Tuple(
-                Enum("NodeModuleId::PackageRoyalty"),
+                Enum("NodeModuleId::SELF"),
                 "claim_royalty"
             ),
             Enum(
@@ -93,7 +93,7 @@ PUBLISH_PACKAGE
         Enum("AccessRule::DenyAll"),         # Default Auth Field
         Map<Tuple, Enum>(         # Method Auth Mutability Field
             Tuple(
-                Enum("NodeModuleId::PackageRoyalty"),
+                Enum("NodeModuleId::SELF"),
                 "set_royalty_config"
             ),
             Enum(
@@ -110,7 +110,7 @@ PUBLISH_PACKAGE
                 )
             ),
             Tuple(
-                Enum("NodeModuleId::PackageRoyalty"),
+                Enum("NodeModuleId::SELF"),
                 "claim_royalty"
             ),
             Enum(

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/auth_zone.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/auth_zone.rtm
@@ -1,0 +1,28 @@
+# Withdraw XRD from account
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "withdraw" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
+
+# Create a proof from bucket, clone it and drop both
+TAKE_FROM_WORKTOP Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
+CREATE_PROOF_FROM_BUCKET Bucket("some_xrd") Proof("proof1");
+CLONE_PROOF Proof("proof1") Proof("proof2");
+DROP_PROOF Proof("proof1");
+DROP_PROOF Proof("proof2");
+
+# Create a proof from account and drop it
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "create_proof_by_amount" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
+POP_FROM_AUTH_ZONE Proof("proof3");
+DROP_PROOF Proof("proof3");
+
+# Compose proofs
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "create_proof_by_amount" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
+CREATE_PROOF_FROM_AUTH_ZONE Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Proof("Proof Name");
+CREATE_PROOF_FROM_AUTH_ZONE_BY_AMOUNT Decimal("1") Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Proof("proof4");
+CREATE_PROOF_FROM_AUTH_ZONE_BY_IDS Array<NonFungibleLocalId>(NonFungibleLocalId("#123#")) Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Proof("proof5");
+CLEAR_AUTH_ZONE;
+
+# Drop all virtual proofs in the auth zone.
+CLEAR_SIGNATURE_PROOFS;
+
+# Drop all proofs, and move resources to account
+DROP_ALL_PROOFS;
+CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/fungible/no_initial_supply.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/fungible/no_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/fungible/with_initial_supply.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/fungible/with_initial_supply.rtm
@@ -9,7 +9,7 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
@@ -57,6 +57,6 @@ CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
 # Depositing the entirety of the initial supply of the newly created resource into our account 
 # component.
 CALL_METHOD
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/non_fungible/no_initial_supply.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/non_fungible/no_initial_supply.rtm
@@ -9,42 +9,43 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Creating a new resource 
 CREATE_NON_FUNGIBLE_RESOURCE
     Enum("NonFungibleIdType::Integer")
+    Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum(0u8, 64u8), Array<String>())
     Map<String, String>(
         "name", "MyResource",                                        # Resource Name
         "description", "A very innovative and important resource"    # Resource Description
     )
     Map<Enum, Tuple>(
-        # This array of tuples defines the behavior of the resource. Each element in the array 
+        # This array of tuples defines the behavior of the resource. Each element in the array
         # defines different resource behaviors. As an example, the first element in this array
         # defines the withdraw behavior while the second element in the array defines the deposit
         # behavior.
-        # 
-        # Each tuple of the array is made up of two elements: 
+        #
+        # Each tuple of the array is made up of two elements:
         # 1. An enum of the `ResourceMethodAuthKey` or the method that we would like to define the
-        #    behavior of. 
-        # 2. A tuple of two elements: 
-        #       a. The current behaviour. 
-        #       b. The mutability of the behaviour. As in, who can change the current behavior in 
+        #    behavior of.
+        # 2. A tuple of two elements:
+        #       a. The current behaviour.
+        #       b. The mutability of the behaviour. As in, who can change the current behavior in
         #          the future.
-        # 
-        # Lets take `Tuple(Enum("ResourceMethodAuthKey::Withdraw"), Tuple(Enum("AccessRule::AllowAll"), Enum("AccessRule::DenyAll")))` as an 
+        #
+        # Lets take `Tuple(Enum("ResourceMethodAuthKey::Withdraw"), Tuple(Enum("AccessRule::AllowAll"), Enum("AccessRule::DenyAll")))` as an
         # example. This means that anybody who is in possession of the resource may withdraw it from
         # a vault that they control. This behavior is permanent and can not be changed by anybody
         # as the mutability is a `Enum("AccessRule::DenyAll")`.
-        # 
+        #
         #        ┌ We Are customizing the "Withdraw" behavior of the resource
-        #        │                       
+        #        │
         #        │                       ┌ The resource may be withdrawn by anybody who has it
-        #        │                       │                 
+        #        │                       │
         #        │                       │                 ┌ The withdraw behavior (the resource is withdrawable by
-        #        │                       │                 │ by anybody who has the resource) is permanent and can't 
+        #        │                       │                 │ by anybody who has the resource) is permanent and can't
         #        │                       │                 │ be changed in the future.
         #        │                       │                 │
         Enum("ResourceMethodAuthKey::Withdraw"), Tuple(Enum("AccessRule::AllowAll"), Enum("AccessRule::DenyAll")),

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/non_fungible/with_initial_supply.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/creation/non_fungible/with_initial_supply.rtm
@@ -9,13 +9,14 @@
 
 # Locking 10 XRD in fees from the account component. 
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
 # Creating a new resource 
 CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     Enum("NonFungibleIdType::Integer")
+    Tuple(Tuple(Array<Enum>(), Array<Tuple>(), Array<Enum>()), Enum(0u8, 64u8), Array<String>())
     Map<String, String>(
         "name", "MyResource",                                        # Resource Name
         "description", "A very innovative and important resource"    # Resource Description
@@ -52,15 +53,12 @@ CREATE_NON_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
     )
     Map<NonFungibleLocalId, Tuple>(
         NonFungibleLocalId("${non_fungible_local_id}"),
-        Tuple(
-            Tuple("Hello World", Decimal("12")),        # The immutable part of the data
-            Tuple(12u8, 19u128)                         # The mutable part of the data
-        )
+        Tuple("Hello World", Decimal("12"))
     );
 
 # Depositing the entirety of the initial supply of the newly created resource into our account 
 # component.
 CALL_METHOD
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/mint/fungible/mint.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/mint/fungible/mint.rtm
@@ -13,7 +13,7 @@
 # a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
 # its own method call and creating a proof will be its own method call.
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
@@ -32,6 +32,6 @@ MINT_FUNGIBLE
 
 # Depositing the entirety of the newly minted tokens into out account
 CALL_METHOD
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/mint/non_fungible/mint.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/mint/non_fungible/mint.rtm
@@ -13,7 +13,7 @@
 # a method for creating a proof and locking a fee at the same time. Therefore, locking a fee will be
 # its own method call and creating a proof will be its own method call.
 CALL_METHOD 
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "lock_fee"
     Decimal("10");
 
@@ -30,16 +30,15 @@ CALL_METHOD
 # is user specified.
 MINT_NON_FUNGIBLE
     Address("${mintable_resource_address}")
-    Map<NonFungibleLocalId, Tuple>(
-        NonFungibleLocalId("${non_fungible_local_id}"), 
-        Tuple(
-            Tuple("Hello World", Decimal("12")),        # The immutable part of the data    
-            Tuple(12u8, 19u128)                         # The mutable part of the data
+    Tuple(
+        Map<NonFungibleLocalId, Tuple>(
+            NonFungibleLocalId("${non_fungible_local_id}"),
+            Tuple(Tuple())
         )
     );
 
 # Depositing the entirety of the newly minted tokens into out account
 CALL_METHOD
-    Address("${account_component_address}")
+    Address("${account_component_address}") 
     "deposit_batch"
     Expression("ENTIRE_WORKTOP");

--- a/radix-engine-toolkit/tests/test_vector/manifest/resources/worktop.rtm
+++ b/radix-engine-toolkit/tests/test_vector/manifest/resources/worktop.rtm
@@ -9,20 +9,10 @@ ASSERT_WORKTOP_CONTAINS Address("resource_sim1qzhdk7tq68u8msj38r6v6yqa5myc64ejx3
 
 # Create a proof from bucket, clone it and drop both
 TAKE_FROM_WORKTOP Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("some_xrd");
-CREATE_PROOF_FROM_BUCKET Bucket("some_xrd") Proof("proof1");
-CLONE_PROOF Proof("proof1") Proof("proof2");
-DROP_PROOF Proof("proof1");
-DROP_PROOF Proof("proof2");
-
-# Create a proof from account and drop it
-CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "create_proof_by_amount" Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Decimal("5.0");
-POP_FROM_AUTH_ZONE Proof("proof3");
-DROP_PROOF Proof("proof3");
 
 # Return a bucket to worktop
 RETURN_TO_WORKTOP Bucket("some_xrd");
 TAKE_FROM_WORKTOP_BY_IDS Array<NonFungibleLocalId>(NonFungibleLocalId("#1#")) Address("resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag") Bucket("nfts");
 
-# Drop all proofs, cancel all buckets and move resources to account
-DROP_ALL_PROOFS;
+# Move all resources in worktop to account
 CALL_METHOD Address("account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064") "deposit_batch" Expression("ENTIRE_WORKTOP");

--- a/schema/Cargo.toml
+++ b/schema/Cargo.toml
@@ -15,8 +15,8 @@ radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 serde = "1.0.152"
 convert_case = "0.6.0"
 
-sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
-scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "utils" }
-native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc", package = "transaction" }
-radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-f78089-no-mimalloc" }
+sbor = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }
+scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "utils" }
+native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494", package = "transaction" }
+radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-a2cc02494" }

--- a/schema/out/examples/request-examples.md
+++ b/schema/out/examples/request-examples.md
@@ -145,101 +145,6 @@ This document contains examples and descriptions of the different requests and r
           }
         },
         {
-          "instruction": "CREATE_PROOF_FROM_BUCKET",
-          "bucket": {
-            "type": "Bucket",
-            "identifier": {
-              "type": "String",
-              "value": "bucket2"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "CLONE_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "CALL_METHOD",
-          "component_address": {
-            "type": "Address",
-            "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-          },
-          "method_name": {
-            "type": "String",
-            "value": "create_proof_by_amount"
-          },
-          "arguments": [
-            {
-              "type": "Address",
-              "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-            },
-            {
-              "type": "Decimal",
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "instruction": "POP_FROM_AUTH_ZONE",
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
           "instruction": "RETURN_TO_WORKTOP",
           "bucket": {
             "type": "Bucket",
@@ -271,9 +176,6 @@ This document contains examples and descriptions of the different requests and r
               "value": "bucket3"
             }
           }
-        },
-        {
-          "instruction": "DROP_ALL_PROOFS"
         },
         {
           "instruction": "CALL_METHOD",
@@ -400,101 +302,6 @@ This document contains examples and descriptions of the different requests and r
         }
       },
       {
-        "instruction": "CREATE_PROOF_FROM_BUCKET",
-        "bucket": {
-          "type": "Bucket",
-          "identifier": {
-            "type": "String",
-            "value": "bucket2"
-          }
-        },
-        "into_proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof1"
-          }
-        }
-      },
-      {
-        "instruction": "CLONE_PROOF",
-        "proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof1"
-          }
-        },
-        "into_proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof2"
-          }
-        }
-      },
-      {
-        "instruction": "DROP_PROOF",
-        "proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof1"
-          }
-        }
-      },
-      {
-        "instruction": "DROP_PROOF",
-        "proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof2"
-          }
-        }
-      },
-      {
-        "instruction": "CALL_METHOD",
-        "component_address": {
-          "type": "Address",
-          "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-        },
-        "method_name": {
-          "type": "String",
-          "value": "create_proof_by_amount"
-        },
-        "arguments": [
-          {
-            "type": "Address",
-            "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-          },
-          {
-            "type": "Decimal",
-            "value": "5"
-          }
-        ]
-      },
-      {
-        "instruction": "POP_FROM_AUTH_ZONE",
-        "into_proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof3"
-          }
-        }
-      },
-      {
-        "instruction": "DROP_PROOF",
-        "proof": {
-          "type": "Proof",
-          "identifier": {
-            "type": "String",
-            "value": "proof3"
-          }
-        }
-      },
-      {
         "instruction": "RETURN_TO_WORKTOP",
         "bucket": {
           "type": "Bucket",
@@ -526,9 +333,6 @@ This document contains examples and descriptions of the different requests and r
             "value": "bucket3"
           }
         }
-      },
-      {
-        "instruction": "DROP_ALL_PROOFS"
       },
       {
         "instruction": "CALL_METHOD",
@@ -573,7 +377,7 @@ This document contains examples and descriptions of the different requests and r
   "manifest": {
     "instructions": {
       "type": "String",
-      "value": "CALL_METHOD\n    Address(\"account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064\")\n    \"withdraw\"\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Decimal(\"5\");\nTAKE_FROM_WORKTOP_BY_AMOUNT\n    Decimal(\"2\")\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket1\");\nCALL_METHOD\n    Address(\"component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum\")\n    \"buy_gumball\"\n    Bucket(\"bucket1\");\nASSERT_WORKTOP_CONTAINS_BY_AMOUNT\n    Decimal(\"3\")\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\");\nASSERT_WORKTOP_CONTAINS\n    Address(\"resource_sim1qzhdk7tq68u8msj38r6v6yqa5myc64ejx3ud20zlh9gseqtux6\");\nTAKE_FROM_WORKTOP\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket2\");\nCREATE_PROOF_FROM_BUCKET\n    Bucket(\"bucket2\")\n    Proof(\"proof1\");\nCLONE_PROOF\n    Proof(\"proof1\")\n    Proof(\"proof2\");\nDROP_PROOF\n    Proof(\"proof1\");\nDROP_PROOF\n    Proof(\"proof2\");\nCALL_METHOD\n    Address(\"account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064\")\n    \"create_proof_by_amount\"\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Decimal(\"5\");\nPOP_FROM_AUTH_ZONE\n    Proof(\"proof3\");\nDROP_PROOF\n    Proof(\"proof3\");\nRETURN_TO_WORKTOP\n    Bucket(\"bucket2\");\nTAKE_FROM_WORKTOP_BY_IDS\n    Array<NonFungibleLocalId>(NonFungibleLocalId(\"#1#\"))\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket3\");\nDROP_ALL_PROOFS;\nCALL_METHOD\n    Address(\"account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064\")\n    \"deposit_batch\"\n    Expression(\"ENTIRE_WORKTOP\");\n"
+      "value": "CALL_METHOD\n    Address(\"account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064\")\n    \"withdraw\"\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Decimal(\"5\");\nTAKE_FROM_WORKTOP_BY_AMOUNT\n    Decimal(\"2\")\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket1\");\nCALL_METHOD\n    Address(\"component_sim1q2f9vmyrmeladvz0ejfttcztqv3genlsgpu9vue83mcs835hum\")\n    \"buy_gumball\"\n    Bucket(\"bucket1\");\nASSERT_WORKTOP_CONTAINS_BY_AMOUNT\n    Decimal(\"3\")\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\");\nASSERT_WORKTOP_CONTAINS\n    Address(\"resource_sim1qzhdk7tq68u8msj38r6v6yqa5myc64ejx3ud20zlh9gseqtux6\");\nTAKE_FROM_WORKTOP\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket2\");\nRETURN_TO_WORKTOP\n    Bucket(\"bucket2\");\nTAKE_FROM_WORKTOP_BY_IDS\n    Array<NonFungibleLocalId>(NonFungibleLocalId(\"#1#\"))\n    Address(\"resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag\")\n    Bucket(\"bucket3\");\nCALL_METHOD\n    Address(\"account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064\")\n    \"deposit_batch\"\n    Expression(\"ENTIRE_WORKTOP\");\n"
     },
     "blobs": []
   }
@@ -760,101 +564,6 @@ This document contains examples and descriptions of the different requests and r
           }
         },
         {
-          "instruction": "CREATE_PROOF_FROM_BUCKET",
-          "bucket": {
-            "type": "Bucket",
-            "identifier": {
-              "type": "String",
-              "value": "bucket2"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "CLONE_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "CALL_METHOD",
-          "component_address": {
-            "type": "Address",
-            "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-          },
-          "method_name": {
-            "type": "String",
-            "value": "create_proof_by_amount"
-          },
-          "arguments": [
-            {
-              "type": "Address",
-              "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-            },
-            {
-              "type": "Decimal",
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "instruction": "POP_FROM_AUTH_ZONE",
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
           "instruction": "RETURN_TO_WORKTOP",
           "bucket": {
             "type": "Bucket",
@@ -888,9 +597,6 @@ This document contains examples and descriptions of the different requests and r
           }
         },
         {
-          "instruction": "DROP_ALL_PROOFS"
-        },
-        {
           "instruction": "CALL_METHOD",
           "component_address": {
             "type": "Address",
@@ -920,7 +626,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "compiled_intent": "4d21022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d21018300202000"
+  "compiled_intent": "4d21022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000"
 }
 ```
 </details>
@@ -941,7 +647,7 @@ This document contains examples and descriptions of the different requests and r
 ```json
 {
   "instructions_output_kind": "Parsed",
-  "compiled_intent": "4d21022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d21018300202000"
+  "compiled_intent": "4d21022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000"
 }
 ```
 </details>
@@ -1061,101 +767,6 @@ This document contains examples and descriptions of the different requests and r
           }
         },
         {
-          "instruction": "CREATE_PROOF_FROM_BUCKET",
-          "bucket": {
-            "type": "Bucket",
-            "identifier": {
-              "type": "String",
-              "value": "bucket2"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "CLONE_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          },
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof1"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof2"
-            }
-          }
-        },
-        {
-          "instruction": "CALL_METHOD",
-          "component_address": {
-            "type": "Address",
-            "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-          },
-          "method_name": {
-            "type": "String",
-            "value": "create_proof_by_amount"
-          },
-          "arguments": [
-            {
-              "type": "Address",
-              "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-            },
-            {
-              "type": "Decimal",
-              "value": "5"
-            }
-          ]
-        },
-        {
-          "instruction": "POP_FROM_AUTH_ZONE",
-          "into_proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
-          "instruction": "DROP_PROOF",
-          "proof": {
-            "type": "Proof",
-            "identifier": {
-              "type": "String",
-              "value": "proof3"
-            }
-          }
-        },
-        {
           "instruction": "RETURN_TO_WORKTOP",
           "bucket": {
             "type": "Bucket",
@@ -1187,9 +798,6 @@ This document contains examples and descriptions of the different requests and r
               "value": "bucket3"
             }
           }
-        },
-        {
-          "instruction": "DROP_ALL_PROOFS"
         },
         {
           "instruction": "CALL_METHOD",
@@ -1342,101 +950,6 @@ This document contains examples and descriptions of the different requests and r
             }
           },
           {
-            "instruction": "CREATE_PROOF_FROM_BUCKET",
-            "bucket": {
-              "type": "Bucket",
-              "identifier": {
-                "type": "String",
-                "value": "bucket2"
-              }
-            },
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            }
-          },
-          {
-            "instruction": "CLONE_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            },
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof2"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof2"
-              }
-            }
-          },
-          {
-            "instruction": "CALL_METHOD",
-            "component_address": {
-              "type": "Address",
-              "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-            },
-            "method_name": {
-              "type": "String",
-              "value": "create_proof_by_amount"
-            },
-            "arguments": [
-              {
-                "type": "Address",
-                "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-              },
-              {
-                "type": "Decimal",
-                "value": "5"
-              }
-            ]
-          },
-          {
-            "instruction": "POP_FROM_AUTH_ZONE",
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof3"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof3"
-              }
-            }
-          },
-          {
             "instruction": "RETURN_TO_WORKTOP",
             "bucket": {
               "type": "Bucket",
@@ -1470,9 +983,6 @@ This document contains examples and descriptions of the different requests and r
             }
           },
           {
-            "instruction": "DROP_ALL_PROOFS"
-          },
-          {
             "instruction": "CALL_METHOD",
             "component_address": {
               "type": "Address",
@@ -1497,30 +1007,30 @@ This document contains examples and descriptions of the different requests and r
   "intent_signatures": [
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "01500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+      "signature": "0002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
     },
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac02"
+      "signature": "00c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3"
     },
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "00b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f41"
+      "signature": "0133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e83"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
-      "signature": "dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a801"
+      "signature": "a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
-      "signature": "a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f102"
+      "signature": "76ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d701"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
-      "signature": "ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+      "signature": "b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
     }
   ]
 }
@@ -1532,7 +1042,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "compiled_intent": "4d210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+  "compiled_intent": "4d210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
 }
 ```
 </details>
@@ -1553,7 +1063,7 @@ This document contains examples and descriptions of the different requests and r
 ```json
 {
   "instructions_output_kind": "Parsed",
-  "compiled_signed_intent": "4d210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+  "compiled_signed_intent": "4d210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
 }
 ```
 </details>
@@ -1674,101 +1184,6 @@ This document contains examples and descriptions of the different requests and r
             }
           },
           {
-            "instruction": "CREATE_PROOF_FROM_BUCKET",
-            "bucket": {
-              "type": "Bucket",
-              "identifier": {
-                "type": "String",
-                "value": "bucket2"
-              }
-            },
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            }
-          },
-          {
-            "instruction": "CLONE_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            },
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof2"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof1"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof2"
-              }
-            }
-          },
-          {
-            "instruction": "CALL_METHOD",
-            "component_address": {
-              "type": "Address",
-              "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-            },
-            "method_name": {
-              "type": "String",
-              "value": "create_proof_by_amount"
-            },
-            "arguments": [
-              {
-                "type": "Address",
-                "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-              },
-              {
-                "type": "Decimal",
-                "value": "5"
-              }
-            ]
-          },
-          {
-            "instruction": "POP_FROM_AUTH_ZONE",
-            "into_proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof3"
-              }
-            }
-          },
-          {
-            "instruction": "DROP_PROOF",
-            "proof": {
-              "type": "Proof",
-              "identifier": {
-                "type": "String",
-                "value": "proof3"
-              }
-            }
-          },
-          {
             "instruction": "RETURN_TO_WORKTOP",
             "bucket": {
               "type": "Bucket",
@@ -1802,9 +1217,6 @@ This document contains examples and descriptions of the different requests and r
             }
           },
           {
-            "instruction": "DROP_ALL_PROOFS"
-          },
-          {
             "instruction": "CALL_METHOD",
             "component_address": {
               "type": "Address",
@@ -1829,30 +1241,30 @@ This document contains examples and descriptions of the different requests and r
   "intent_signatures": [
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "01500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+      "signature": "0002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
     },
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac02"
+      "signature": "00c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3"
     },
     {
       "curve": "EcdsaSecp256k1",
-      "signature": "00b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f41"
+      "signature": "0133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e83"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
-      "signature": "dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a801"
+      "signature": "a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
-      "signature": "a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f102"
+      "signature": "76ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d701"
     },
     {
       "curve": "EddsaEd25519",
       "public_key": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
-      "signature": "ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+      "signature": "b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
     }
   ]
 }
@@ -1986,101 +1398,6 @@ This document contains examples and descriptions of the different requests and r
               }
             },
             {
-              "instruction": "CREATE_PROOF_FROM_BUCKET",
-              "bucket": {
-                "type": "Bucket",
-                "identifier": {
-                  "type": "String",
-                  "value": "bucket2"
-                }
-              },
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              }
-            },
-            {
-              "instruction": "CLONE_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              },
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof2"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof2"
-                }
-              }
-            },
-            {
-              "instruction": "CALL_METHOD",
-              "component_address": {
-                "type": "Address",
-                "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-              },
-              "method_name": {
-                "type": "String",
-                "value": "create_proof_by_amount"
-              },
-              "arguments": [
-                {
-                  "type": "Address",
-                  "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-                },
-                {
-                  "type": "Decimal",
-                  "value": "5"
-                }
-              ]
-            },
-            {
-              "instruction": "POP_FROM_AUTH_ZONE",
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof3"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof3"
-                }
-              }
-            },
-            {
               "instruction": "RETURN_TO_WORKTOP",
               "bucket": {
                 "type": "Bucket",
@@ -2114,9 +1431,6 @@ This document contains examples and descriptions of the different requests and r
               }
             },
             {
-              "instruction": "DROP_ALL_PROOFS"
-            },
-            {
               "instruction": "CALL_METHOD",
               "component_address": {
                 "type": "Address",
@@ -2141,36 +1455,36 @@ This document contains examples and descriptions of the different requests and r
     "intent_signatures": [
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "01500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+        "signature": "0002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
       },
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac02"
+        "signature": "00c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3"
       },
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "00b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f41"
+        "signature": "0133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e83"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
-        "signature": "dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a801"
+        "signature": "a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
-        "signature": "a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f102"
+        "signature": "76ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d701"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
-        "signature": "ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+        "signature": "b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
       }
     ]
   },
   "notary_signature": {
     "curve": "EcdsaSecp256k1",
-    "signature": "01675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+    "signature": "003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
   }
 }
 ```
@@ -2181,7 +1495,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "compiled_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06220001210120074101675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+  "compiled_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e2200012101200741003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
 }
 ```
 </details>
@@ -2202,7 +1516,7 @@ This document contains examples and descriptions of the different requests and r
 ```json
 {
   "instructions_output_kind": "Parsed",
-  "compiled_notarized_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06220001210120074101675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+  "compiled_notarized_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e2200012101200741003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
 }
 ```
 </details>
@@ -2324,101 +1638,6 @@ This document contains examples and descriptions of the different requests and r
               }
             },
             {
-              "instruction": "CREATE_PROOF_FROM_BUCKET",
-              "bucket": {
-                "type": "Bucket",
-                "identifier": {
-                  "type": "String",
-                  "value": "bucket2"
-                }
-              },
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              }
-            },
-            {
-              "instruction": "CLONE_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              },
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof2"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof1"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof2"
-                }
-              }
-            },
-            {
-              "instruction": "CALL_METHOD",
-              "component_address": {
-                "type": "Address",
-                "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-              },
-              "method_name": {
-                "type": "String",
-                "value": "create_proof_by_amount"
-              },
-              "arguments": [
-                {
-                  "type": "Address",
-                  "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-                },
-                {
-                  "type": "Decimal",
-                  "value": "5"
-                }
-              ]
-            },
-            {
-              "instruction": "POP_FROM_AUTH_ZONE",
-              "into_proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof3"
-                }
-              }
-            },
-            {
-              "instruction": "DROP_PROOF",
-              "proof": {
-                "type": "Proof",
-                "identifier": {
-                  "type": "String",
-                  "value": "proof3"
-                }
-              }
-            },
-            {
               "instruction": "RETURN_TO_WORKTOP",
               "bucket": {
                 "type": "Bucket",
@@ -2452,9 +1671,6 @@ This document contains examples and descriptions of the different requests and r
               }
             },
             {
-              "instruction": "DROP_ALL_PROOFS"
-            },
-            {
               "instruction": "CALL_METHOD",
               "component_address": {
                 "type": "Address",
@@ -2479,36 +1695,36 @@ This document contains examples and descriptions of the different requests and r
     "intent_signatures": [
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "01500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+        "signature": "0002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
       },
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac02"
+        "signature": "00c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3"
       },
       {
         "curve": "EcdsaSecp256k1",
-        "signature": "00b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f41"
+        "signature": "0133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e83"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
-        "signature": "dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a801"
+        "signature": "a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
-        "signature": "a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f102"
+        "signature": "76ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d701"
       },
       {
         "curve": "EddsaEd25519",
         "public_key": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
-        "signature": "ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+        "signature": "b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
       }
     ]
   },
   "notary_signature": {
     "curve": "EcdsaSecp256k1",
-    "signature": "01675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+    "signature": "003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
   }
 }
 ```
@@ -2530,7 +1746,7 @@ This document contains examples and descriptions of the different requests and r
 ```json
 {
   "instructions_output_kind": "Parsed",
-  "compiled_unknown_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06220001210120074101675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+  "compiled_unknown_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e2200012101200741003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
 }
 ```
 </details>
@@ -2654,101 +1870,6 @@ This document contains examples and descriptions of the different requests and r
                 }
               },
               {
-                "instruction": "CREATE_PROOF_FROM_BUCKET",
-                "bucket": {
-                  "type": "Bucket",
-                  "identifier": {
-                    "type": "String",
-                    "value": "bucket2"
-                  }
-                },
-                "into_proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof1"
-                  }
-                }
-              },
-              {
-                "instruction": "CLONE_PROOF",
-                "proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof1"
-                  }
-                },
-                "into_proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof2"
-                  }
-                }
-              },
-              {
-                "instruction": "DROP_PROOF",
-                "proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof1"
-                  }
-                }
-              },
-              {
-                "instruction": "DROP_PROOF",
-                "proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof2"
-                  }
-                }
-              },
-              {
-                "instruction": "CALL_METHOD",
-                "component_address": {
-                  "type": "Address",
-                  "address": "account_sim1q02r73u7nv47h80e30pc3q6ylsj7mgvparm3pnsm780qgsy064"
-                },
-                "method_name": {
-                  "type": "String",
-                  "value": "create_proof_by_amount"
-                },
-                "arguments": [
-                  {
-                    "type": "Address",
-                    "address": "resource_sim1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqzqu57yag"
-                  },
-                  {
-                    "type": "Decimal",
-                    "value": "5"
-                  }
-                ]
-              },
-              {
-                "instruction": "POP_FROM_AUTH_ZONE",
-                "into_proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof3"
-                  }
-                }
-              },
-              {
-                "instruction": "DROP_PROOF",
-                "proof": {
-                  "type": "Proof",
-                  "identifier": {
-                    "type": "String",
-                    "value": "proof3"
-                  }
-                }
-              },
-              {
                 "instruction": "RETURN_TO_WORKTOP",
                 "bucket": {
                   "type": "Bucket",
@@ -2782,9 +1903,6 @@ This document contains examples and descriptions of the different requests and r
                 }
               },
               {
-                "instruction": "DROP_ALL_PROOFS"
-              },
-              {
                 "instruction": "CALL_METHOD",
                 "component_address": {
                   "type": "Address",
@@ -2809,36 +1927,36 @@ This document contains examples and descriptions of the different requests and r
       "intent_signatures": [
         {
           "curve": "EcdsaSecp256k1",
-          "signature": "01500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+          "signature": "0002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
         },
         {
           "curve": "EcdsaSecp256k1",
-          "signature": "008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac02"
+          "signature": "00c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3"
         },
         {
           "curve": "EcdsaSecp256k1",
-          "signature": "00b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f41"
+          "signature": "0133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e83"
         },
         {
           "curve": "EddsaEd25519",
           "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29",
-          "signature": "dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a801"
+          "signature": "a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b"
         },
         {
           "curve": "EddsaEd25519",
           "public_key": "7422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674",
-          "signature": "a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f102"
+          "signature": "76ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d701"
         },
         {
           "curve": "EddsaEd25519",
           "public_key": "f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b",
-          "signature": "ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06"
+          "signature": "b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e"
         }
       ]
     },
     "notary_signature": {
       "curve": "EcdsaSecp256k1",
-      "signature": "01675b33e76358e6646968c6d2d7576f3187b756a0cd9e6288557790e5173d5ba9086dae187945315ed4d2de010e6f4f16a47f3bd33809448f8b66bcb452d8cf4b"
+      "signature": "003ab31821d3564bbae70a09a2ba73ac746155cb2d9f4f2776a2e35ecb5dd6eb9539fb4ba8dca92e8e526a9e599b5939c183b1568f8fd38479ee64f1269735c54f"
     }
   }
 }
@@ -3238,7 +2356,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "compiled_notarized_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06220001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf",
+  "compiled_notarized_intent": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e22000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404",
   "validation_config": {
     "network_id": "242",
     "min_cost_unit_limit": "1000000",
@@ -3346,7 +2464,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "payload": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220221120038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0877697468647261772007404d210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042003800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2007084d2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040d0181010000000e0182020000000f0182020000000f01820300000020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c166372656174655f70726f6f665f62795f616d6f756e742007404d210280000000000000000000000000000000000000000000000000000004850000f4448291634500000000000000000000000000000000000000000000000007000f01820400000003018101000000020220870101000000000000000180000000000000000000000000000000000000000000000000000004100020038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f62617463682007054d210183002020002022060001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf00012101200741008e79cd7bbed0563f33dc5b66e5de011e6b6cf526a3818398a1275051f253dd49229e30605807d26777eeaffcc27c71255e787d4de7776b06e234379f27c5ac020001210120074100b36b66143b9d6ae1f71ce8c4ea41b5492cc68e0d40acf1fb1637b827c94f9c0831ebe2898b8177713e3eec6a9ea9a2496e1a436e2e9973a8dfa6632a26f60f4101022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740dff90a5986ec36936772f6d50a63a4282ef5b0e2a0fc25ce1a75138558016f3ef51f5e5a76ddc6687c7450ebdb161a94032a614ff5238b6c45b7b48e2784a80101022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe26742101200740a214fac1c8477e579a4c4e7304a236618bfd2326b9fd3d8ee3012389706a82f0f282361a4656e742b81c780d674a6aae9c8b0fab9338973c2edb6eefd9c0f1020102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740ae4e36bc940e4b71a90447dee1e69664c3c8da8758b81c0c6290873045229c90e4845a6b3b0462e5e77e8c8c8ab705d1be46564ccf7954ea7c08bc194f725c06220001210120074101500a907e047503be620a09287c9ecc550d0b76c2006e52199e493eb2bd4a2de703d9f80fe01d620183469003c0e5f2c7a8ea428e428b9cb9e0f0319900e60fcf"
+  "payload": "4d2102210221022109070107f20a00020000000000000a10020000000000000a220000000000000022000120072103c32f9761dd3f961a3d12747e54db6b821bd022ef92b9ebf591bfe186885baa2101010900e1f505080000210220220921038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c087769746864726177210280000000000000000000000000000000000000000000000000000004850000f444829163450000000000000000000000000000000000000000000000000102850000c84e676dc11b000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000042103800292566c83de7fd6b04fcc92b5e04b03228ccff040785673278ef10c0b6275795f67756d62616c6c2101810000000005028500002cf61a24a2290000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000404018000aedb7960d1f87dc25138f4cd101da6c98d57323478d53c5fb9510001800000000000000000000000000000000000000000000000000000040301810100000002022087010100000000000000018000000000000000000000000000000000000000000000000000000421038003d43f479e9b2beb9df98bc3888344fc25eda181e8f710ce1bf1de0c0d6465706f7369745f626174636821018300202000202206000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b4040001210120074100c22fb1f22d1e4ffc2948777088010d1e69c01ecdc4ec81f5bd6acd22d784d0bb48c49badf8d82f86f115ef1dd5f67d1d8b2a9146de2f4e3b52a1b453bbde3da3000121012007410133e711969ece4837a27868f3ba0fe9217daff81e7af0dd65628b2dc286645d1b577173c59caf4f03529ed24a140dbc0491269a2a576e62dc0eeaf4a6d72a0e8301022007204cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba292101200740a77bb06e6cb75678892a9eec6294baa5ddd2f88e713ffe495d88813417bb4901a509dabbf7421b9cd06205bdfafce7963281c3f2dd1b9c25b6d84d0983e0d30b01022007207422b9887598068e32c4448a949adb290d0f4e35b9e01b0ee5f1a1e600fe2674210120074076ea99232acc86d9d13367daf4cec07dc79a5408cf298d0b46f376221bbdae7c5ab8f154d3f1fdbc111a4ef1a794ffce0206db73ad9b915dc030df50e5e0d7010102200720f381626e41e7027ea431bfe3009e94bdd25a746beec468948d6c3c7c5dc9a54b2101200740b54303ca01c34ec9b9b25b7427d6375019925ba7373da62bf6271d8efc07384bbe157be42eebb25f210c525fb2cbd1deed93c6a22ff4b23375524188fda3f00e22000121012007410002cd7f6ed8cd67846d9d53a8363d76333e8fd820bb711f958d3e2028cc73ae924a3f498a4b4aaa29cf181455d6c2b45503cba74676f314508bfcf80a6881b404"
 }
 ```
 </details>
@@ -3356,7 +2474,7 @@ This document contains examples and descriptions of the different requests and r
     
 ```json
 {
-  "value": "564167b843677b9185ac801c75c178936fcfb81e632c8ff6bfc6f9155bb64af6"
+  "value": "f2a7904a9bd4a77254d7ac707eedcbd54dde4932de35b77db605ad45d88cd469"
 }
 ```
 </details>

--- a/schema/out/schema/analyze_manifest_request.json
+++ b/schema/out/schema/analyze_manifest_request.json
@@ -887,6 +887,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1227,14 +1247,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1411,7 +1431,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2180,6 +2207,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2188,7 +2258,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2199,6 +2270,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2231,7 +2310,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2242,6 +2322,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/analyze_manifest_with_preview_context_request.json
+++ b/schema/out/schema/analyze_manifest_with_preview_context_request.json
@@ -893,6 +893,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1233,14 +1253,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1417,7 +1437,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2186,6 +2213,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2194,7 +2264,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2205,6 +2276,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2237,7 +2316,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2248,6 +2328,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/compile_notarized_transaction_request.json
+++ b/schema/out/schema/compile_notarized_transaction_request.json
@@ -1258,6 +1258,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1598,14 +1618,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1782,7 +1802,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2551,6 +2578,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2559,7 +2629,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2570,6 +2641,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2602,7 +2681,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2613,6 +2693,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/compile_signed_transaction_intent_request.json
+++ b/schema/out/schema/compile_signed_transaction_intent_request.json
@@ -1157,6 +1157,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1497,14 +1517,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1681,7 +1701,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2450,6 +2477,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2458,7 +2528,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2469,6 +2540,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2501,7 +2580,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2512,6 +2592,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/compile_transaction_intent_request.json
+++ b/schema/out/schema/compile_transaction_intent_request.json
@@ -1063,6 +1063,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1403,14 +1423,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1587,7 +1607,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2356,6 +2383,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2364,7 +2434,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2375,6 +2446,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2407,7 +2486,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2418,6 +2498,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/convert_manifest_request.json
+++ b/schema/out/schema/convert_manifest_request.json
@@ -904,6 +904,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1244,14 +1264,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1428,7 +1448,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2197,6 +2224,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2205,7 +2275,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2216,6 +2287,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2248,7 +2327,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2259,6 +2339,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/convert_manifest_response.json
+++ b/schema/out/schema/convert_manifest_response.json
@@ -864,6 +864,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1204,14 +1224,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1388,7 +1408,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2157,6 +2184,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2165,7 +2235,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2176,6 +2247,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2208,7 +2287,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2219,6 +2299,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/decompile_notarized_transaction_response.json
+++ b/schema/out/schema/decompile_notarized_transaction_response.json
@@ -1258,6 +1258,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1598,14 +1618,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1782,7 +1802,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2551,6 +2578,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2559,7 +2629,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2570,6 +2641,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2602,7 +2681,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2613,6 +2693,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/decompile_signed_transaction_intent_response.json
+++ b/schema/out/schema/decompile_signed_transaction_intent_response.json
@@ -1157,6 +1157,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1497,14 +1517,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1681,7 +1701,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2450,6 +2477,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2458,7 +2528,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2469,6 +2540,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2501,7 +2580,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2512,6 +2592,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/decompile_transaction_intent_response.json
+++ b/schema/out/schema/decompile_transaction_intent_response.json
@@ -1063,6 +1063,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1403,14 +1423,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1587,7 +1607,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2356,6 +2383,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2364,7 +2434,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2375,6 +2446,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2407,7 +2486,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2418,6 +2498,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/decompile_unknown_transaction_intent_response.json
+++ b/schema/out/schema/decompile_unknown_transaction_intent_response.json
@@ -1122,6 +1122,26 @@
           }
         },
         {
+          "description": "Clears all the proofs of signature virtual badges.",
+          "examples": [
+            {
+              "instruction": "CLEAR_SIGNATURE_PROOFS"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "instruction"
+          ],
+          "properties": {
+            "instruction": {
+              "type": "string",
+              "enum": [
+                "CLEAR_SIGNATURE_PROOFS"
+              ]
+            }
+          }
+        },
+        {
           "description": "An instruction to create a proof of the entire amount of a given resource address from the auth zone.",
           "examples": [
             {
@@ -1462,14 +1482,14 @@
           "description": "An instruction to drop a proof.",
           "examples": [
             {
-              "bucket": {
+              "instruction": "DROP_PROOF",
+              "proof": {
                 "identifier": {
                   "type": "String",
-                  "value": "ident"
+                  "value": "proof"
                 },
-                "type": "Bucket"
-              },
-              "instruction": "BURN_RESOURCE"
+                "type": "Proof"
+              }
             }
           ],
           "type": "object",
@@ -1646,7 +1666,14 @@
           "description": "An instruction to burn a bucket of tokens.",
           "examples": [
             {
-              "instruction": "DROP_ALL_PROOFS"
+              "bucket": {
+                "identifier": {
+                  "type": "String",
+                  "value": "ident"
+                },
+                "type": "Bucket"
+              },
+              "instruction": "BURN_RESOURCE"
             }
           ],
           "type": "object",
@@ -2415,6 +2442,49 @@
                 "key_value_kind": "String",
                 "type": "Map",
                 "value_value_kind": "String"
+              },
+              "schema": {
+                "elements": [
+                  {
+                    "elements": [
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Tuple",
+                        "elements": [],
+                        "type": "Array"
+                      },
+                      {
+                        "element_kind": "Enum",
+                        "elements": [],
+                        "type": "Array"
+                      }
+                    ],
+                    "type": "Tuple"
+                  },
+                  {
+                    "fields": [
+                      {
+                        "type": "U8",
+                        "value": "64"
+                      }
+                    ],
+                    "type": "Enum",
+                    "variant": {
+                      "discriminator": "0",
+                      "type": "U8"
+                    }
+                  },
+                  {
+                    "element_kind": "String",
+                    "elements": [],
+                    "type": "Array"
+                  }
+                ],
+                "type": "Tuple"
               }
             }
           ],
@@ -2423,7 +2493,8 @@
             "access_rules",
             "id_type",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2434,6 +2505,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"
@@ -2466,7 +2545,8 @@
             "id_type",
             "initial_supply",
             "instruction",
-            "metadata"
+            "metadata",
+            "schema"
           ],
           "properties": {
             "instruction": {
@@ -2477,6 +2557,14 @@
             },
             "id_type": {
               "description": "The type of the non-fungible id to use for this resource. This field is serialized as an `Enum` from the ManifestAstValue model.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ManifestAstValue"
+                }
+              ]
+            },
+            "schema": {
+              "description": "The schema that all non-fungibles of this resource must adhere to.",
               "allOf": [
                 {
                   "$ref": "#/definitions/ManifestAstValue"

--- a/schema/out/schema/sbor_decode_response.json
+++ b/schema/out/schema/sbor_decode_response.json
@@ -768,6 +768,31 @@
               "$ref": "#/definitions/NonFungibleLocalId"
             }
           }
+        },
+        {
+          "description": "Represents a reference to some RENode.",
+          "examples": [
+            {
+              "type": "Reference",
+              "value": "00000000000000000000000000000000000000000000000000000000000000"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Reference"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/NodeIdentifier"
+            }
+          }
         }
       ]
     },
@@ -1173,6 +1198,19 @@
           "enum": [
             "NonFungibleLocalId"
           ]
+        },
+        {
+          "description": "Represents a reference to some RENode.",
+          "examples": [
+            {
+              "type": "Reference",
+              "value": "00000000000000000000000000000000000000000000000000000000000000"
+            }
+          ],
+          "type": "string",
+          "enum": [
+            "Reference"
+          ]
         }
       ]
     },
@@ -1277,10 +1315,10 @@
       ]
     },
     "NodeIdentifier": {
-      "description": "Represents a Radix Engine persistent node identifier which is 36 bytes long and serialized as a hexadecimal string of length 72 (since hex encoding doubles the number of bytes needed.)",
+      "description": "Represents a Radix Engine persistent node identifier which is 36 bytes long and serialized as a hexadecimal string of length 31 (since hex encoding doubles the number of bytes needed.)",
       "type": "string",
-      "maxLength": 72,
-      "minLength": 72,
+      "maxLength": 31,
+      "minLength": 31,
       "pattern": "[0-9a-fA-F]+"
     },
     "NonFungibleLocalId": {

--- a/schema/out/schema/sbor_encode_request.json
+++ b/schema/out/schema/sbor_encode_request.json
@@ -768,6 +768,31 @@
               "$ref": "#/definitions/NonFungibleLocalId"
             }
           }
+        },
+        {
+          "description": "Represents a reference to some RENode.",
+          "examples": [
+            {
+              "type": "Reference",
+              "value": "00000000000000000000000000000000000000000000000000000000000000"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Reference"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/NodeIdentifier"
+            }
+          }
         }
       ]
     },
@@ -1173,6 +1198,19 @@
           "enum": [
             "NonFungibleLocalId"
           ]
+        },
+        {
+          "description": "Represents a reference to some RENode.",
+          "examples": [
+            {
+              "type": "Reference",
+              "value": "00000000000000000000000000000000000000000000000000000000000000"
+            }
+          ],
+          "type": "string",
+          "enum": [
+            "Reference"
+          ]
         }
       ]
     },
@@ -1277,10 +1315,10 @@
       ]
     },
     "NodeIdentifier": {
-      "description": "Represents a Radix Engine persistent node identifier which is 36 bytes long and serialized as a hexadecimal string of length 72 (since hex encoding doubles the number of bytes needed.)",
+      "description": "Represents a Radix Engine persistent node identifier which is 36 bytes long and serialized as a hexadecimal string of length 31 (since hex encoding doubles the number of bytes needed.)",
       "type": "string",
-      "maxLength": 72,
-      "minLength": 72,
+      "maxLength": 31,
+      "minLength": 31,
       "pattern": "[0-9a-fA-F]+"
     },
     "NonFungibleLocalId": {


### PR DESCRIPTION
# Description

This PR updates the Scrypto dependency to tag `develop-a2cc02494`

# Changelog

* The `CreateNonFungibleResource` and `CreateNonFungibleResourceWithInitialSupply` instructions now accept an additional argument which the schema that all non-fungibles of this resource adhere to.
* Added a new instruction for dropping all of the signature virtual badges & proofs: `ClearSignatureProofs`
* The `ScryptoSborValue` model had a new variant added to it: `Reference`.