### PR TITLE
Feature: Metadata of Newly Created Resources

### DIFF
--- a/cli-json-interface/src/subcommands/transaction/extract_addresses_from_manifest.rs
+++ b/cli-json-interface/src/subcommands/transaction/extract_addresses_from_manifest.rs
@@ -29,7 +29,7 @@ use crate::utils::pretty_print;
 
 #[derive(Parser, Debug)]
 /// Analyzes the manifest for all of the included addresses in the manifest.
-pub struct extractAddressesFromManifest {
+pub struct ExtractAddressesFromManifest {
     /// The path to a manifest file. This can either be a standard `.rtm` file of the manifest in
     /// text form or could be the path to a `.json` file of the JSON based manifest abstract syntax
     /// tree.
@@ -41,7 +41,7 @@ pub struct extractAddressesFromManifest {
     network_id: u8,
 }
 
-impl extractAddressesFromManifest {
+impl ExtractAddressesFromManifest {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> Result<()> {
         // Determine the type of input to expect from the file extension.
         let input_type = match self
@@ -80,7 +80,7 @@ impl extractAddressesFromManifest {
         let response =
             extract_addresses_from_manifest::Handler::fulfill(request).map_err(|error| {
                 RETError::InvocationHandlingError(
-                    InvocationHandlingError::extractAddressesFromManifestError(error),
+                    InvocationHandlingError::ExtractAddressesFromManifestError(error),
                 )
             })?;
         pretty_print(&response, out)

--- a/cli-json-interface/src/subcommands/transaction/mod.rs
+++ b/cli-json-interface/src/subcommands/transaction/mod.rs
@@ -22,7 +22,7 @@ mod extract_addresses_from_manifest;
 /// A subcommand for all transaction related commands.
 #[derive(clap::Subcommand, Debug)]
 pub enum Transaction {
-    extractAddressesFromManifest(extract_addresses_from_manifest::extractAddressesFromManifest),
+    ExtractAddressesFromManifest(extract_addresses_from_manifest::ExtractAddressesFromManifest),
     ConvertManifest(convert_manifest::ConvertManifest),
     Decompile(decompile::Decompile),
 }
@@ -30,7 +30,7 @@ pub enum Transaction {
 impl Transaction {
     pub fn run<O: std::io::Write>(&self, out: &mut O) -> crate::error::Result<()> {
         match self {
-            Self::extractAddressesFromManifest(cmd) => cmd.run(out),
+            Self::ExtractAddressesFromManifest(cmd) => cmd.run(out),
             Self::ConvertManifest(cmd) => cmd.run(out),
             Self::Decompile(cmd) => cmd.run(out),
         }

--- a/radix-engine-toolkit/Cargo.toml
+++ b/radix-engine-toolkit/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0.91"
 regex = "1.7.3"
 
 [dev-dependencies]
+scrypto-unit = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d" }
 lazy_static = { version = "1.4.0" }
 serde_json = { version = "1.0.91" }
 

--- a/radix-engine-toolkit/Cargo.toml
+++ b/radix-engine-toolkit/Cargo.toml
@@ -22,6 +22,7 @@ scrypto_utils = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "d
 native_transaction = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d", package = "transaction" }
 radix-engine = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d", optional = true }
 radix-engine-common = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d" }
+radix-engine-stores = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d", optional = true }
 radix-engine-constants = { git = "https://github.com/radixdlt/radixdlt-scrypto", tag = "develop-624a696d" }
 
 # Hex is used for the internal hex encoding and decoding of values - serde_with::Hex is used for the
@@ -44,4 +45,4 @@ serde_json = { version = "1.0.91" }
 
 [features]
 default = ["radix-engine"]
-radix-engine = ["dep:radix-engine"]
+radix-engine = ["dep:radix-engine", "dep:radix-engine-stores"]

--- a/radix-engine-toolkit/src/error.rs
+++ b/radix-engine-toolkit/src/error.rs
@@ -70,7 +70,7 @@ impl From<std::str::Utf8Error> for InvocationInterpretationError {
 #[serde(tag = "type")]
 pub enum InvocationHandlingError {
     #[cfg(feature = "radix-engine")]
-    analyzeTransactionExecutionError(analyze_transaction_execution::Error),
+    AnalyzeTransactionExecutionError(analyze_transaction_execution::Error),
     InformationError(information::Error),
     ConvertManifestError(convert_manifest::Error),
     CompileTransactionIntentError(compile_transaction_intent::Error),
@@ -88,7 +88,7 @@ pub enum InvocationHandlingError {
     DeriveOlympiaAddressFromPublicKeyError(derive_olympia_address_from_public_key::Error),
     DeriveVirtualAccountAddressError(derive_virtual_account_address::Error),
     DeriveVirtualIdentityAddressError(derive_virtual_identity_address::Error),
-    extractAddressesFromManifestError(extract_addresses_from_manifest::Error),
+    ExtractAddressesFromManifestError(extract_addresses_from_manifest::Error),
     KnownEntityAddressesError(known_entity_addresses::Error),
     StaticallyValidateTransactionError(statically_validate_transaction::Error),
     HashError(hash::Error),
@@ -105,7 +105,7 @@ macro_rules! impl_from {
 }
 
 #[cfg(feature = "radix-engine")]
-impl_from! { analyze_transaction_execution::Error => InvocationHandlingError as analyzeTransactionExecutionError }
+impl_from! { analyze_transaction_execution::Error => InvocationHandlingError as AnalyzeTransactionExecutionError }
 impl_from! { information::Error => InvocationHandlingError as InformationError }
 impl_from! { convert_manifest::Error => InvocationHandlingError as ConvertManifestError }
 impl_from! { compile_transaction_intent::Error => InvocationHandlingError as CompileTransactionIntentError }
@@ -123,7 +123,7 @@ impl_from! { derive_babylon_address_from_olympia_address::Error => InvocationHan
 impl_from! { derive_olympia_address_from_public_key::Error => InvocationHandlingError as DeriveOlympiaAddressFromPublicKeyError }
 impl_from! { derive_virtual_account_address::Error => InvocationHandlingError as DeriveVirtualAccountAddressError }
 impl_from! { derive_virtual_identity_address::Error => InvocationHandlingError as DeriveVirtualIdentityAddressError }
-impl_from! { extract_addresses_from_manifest::Error => InvocationHandlingError as extractAddressesFromManifestError }
+impl_from! { extract_addresses_from_manifest::Error => InvocationHandlingError as ExtractAddressesFromManifestError }
 impl_from! { known_entity_addresses::Error => InvocationHandlingError as KnownEntityAddressesError }
 impl_from! { statically_validate_transaction::Error => InvocationHandlingError as StaticallyValidateTransactionError }
 impl_from! { hash::Error => InvocationHandlingError as HashError }

--- a/radix-engine-toolkit/src/functions/analyze_transaction_execution.rs
+++ b/radix-engine-toolkit/src/functions/analyze_transaction_execution.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 use std::collections::BTreeSet;
+use std::fmt::Debug;
 
 use crate::error::VisitorError;
 use crate::model::address::NetworkAwareNodeId;
@@ -194,6 +195,30 @@ pub struct EncounteredComponents {
     pub access_controller: BTreeSet<NetworkAwareNodeId>,
 }
 
+#[serializable]
+#[serde(tag = "type", content = "value")]
+#[derive(PartialEq, PartialOrd, Eq, Ord)]
+pub enum Source<G, P> {
+    Guaranteed {
+        #[serde(flatten)]
+        value: G,
+    },
+    Predicted {
+        #[serde(flatten)]
+        value: P,
+    },
+}
+
+impl<G, P> Source<G, P> {
+    pub fn guaranteed(value: G) -> Self {
+        Self::Guaranteed { value }
+    }
+
+    pub fn predicted(value: P) -> Self {
+        Self::Predicted { value }
+    }
+}
+
 impl From<BTreeSet<NetworkAwareNodeId>> for EncounteredComponents {
     fn from(value: BTreeSet<NetworkAwareNodeId>) -> Self {
         let mut user_applications = BTreeSet::new();
@@ -340,6 +365,7 @@ impl InvocationHandler<Input, Output> for Handler {
                 request.network_id,
                 resource_changes,
                 worktop_changes,
+                commit.new_resource_addresses().clone(),
             )
         };
         instructions

--- a/radix-engine-toolkit/src/model/mod.rs
+++ b/radix-engine-toolkit/src/model/mod.rs
@@ -19,7 +19,7 @@ pub mod address;
 pub mod constants;
 pub mod crypto;
 pub mod instruction;
-pub mod resource_specifier;
+pub mod resource_quantifier;
 pub mod runtime;
 pub mod transaction;
 pub mod value;

--- a/radix-engine-toolkit/src/model/resource_quantifier.rs
+++ b/radix-engine-toolkit/src/model/resource_quantifier.rs
@@ -26,7 +26,7 @@ use super::address::NetworkAwareNodeId;
 #[serializable]
 #[derive(PartialEq, PartialOrd, Eq, Ord)]
 #[serde(tag = "type")]
-pub enum ResourceSpecifier {
+pub enum ResourceQuantifier {
     // Specifies resources using a decimal quantity.
     Amount {
         /// A specifier of the resource manager, can either be an address for already existing

--- a/radix-engine-toolkit/src/model/resource_specifier.rs
+++ b/radix-engine-toolkit/src/model/resource_specifier.rs
@@ -29,10 +29,10 @@ use super::address::NetworkAwareNodeId;
 pub enum ResourceSpecifier {
     // Specifies resources using a decimal quantity.
     Amount {
-        /// The resource address associated with the resource
-        #[schemars(with = "String")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
-        resource_address: NetworkAwareNodeId,
+        /// A specifier of the resource manager, can either be an address for already existing
+        /// resource managers or an index for newly created resource managers that can not be
+        /// queried through the network gateway.
+        resource_address: ResourceManagerSpecifier,
 
         /// The amount of resources withdrawn from the account. This is a decimal value which is
         /// serialized as a string.
@@ -43,10 +43,10 @@ pub enum ResourceSpecifier {
     },
     // Specifies resources through a set of non-fungible local id.
     Ids {
-        /// The resource address associated with the resource
-        #[schemars(with = "String")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
-        resource_address: NetworkAwareNodeId,
+        /// A specifier of the resource manager, can either be an address for already existing
+        /// resource managers or an index for newly created resource managers that can not be
+        /// queried through the network gateway.
+        resource_address: ResourceManagerSpecifier,
 
         /// The set of non-fungible ids
         #[schemars(regex(pattern = "[+-]?([0-9]*[.])?[0-9]+"))]
@@ -55,5 +55,21 @@ pub enum ResourceSpecifier {
             as = "BTreeSet<serde_with::TryFromInto<crate::model::address::NonFungibleLocalId>>"
         )]
         ids: BTreeSet<NonFungibleLocalId>,
+    },
+}
+
+#[serializable]
+#[derive(PartialEq, PartialOrd, Eq, Ord)]
+#[serde(tag = "type")]
+pub enum ResourceManagerSpecifier {
+    Existing {
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        address: NetworkAwareNodeId,
+    },
+    NewlyCreated {
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        index: u32,
     },
 }

--- a/radix-engine-toolkit/src/model/value/ast/model.rs
+++ b/radix-engine-toolkit/src/model/value/ast/model.rs
@@ -35,7 +35,7 @@ define_kind_enum! {
     #[serializable]
     #[serde(tag = "type")]
     #[schemars(example = "crate::example::value::ast_value::value")]
-    #[derive(Hash, Eq, PartialEq)]
+    #[derive(PartialEq, Eq, Hash)]
     pub enum ManifestAstValue {
         /// A boolean value which can either be true or false
         #[schemars(

--- a/radix-engine-toolkit/src/model/value/macros.rs
+++ b/radix-engine-toolkit/src/model/value/macros.rs
@@ -49,7 +49,7 @@ macro_rules! define_kind_enum {
             }
 
             #[toolkit_derive::serializable]
-            #[derive(Hash, Eq, PartialEq, Copy)]
+            #[derive(PartialEq, PartialOrd, Eq, Ord, Hash, Copy)]
             $vis enum [< $enum_ident Kind >] {
                 $(
                     $(#[$variant_metadata])*

--- a/radix-engine-toolkit/src/model/value/metadata/bridge.rs
+++ b/radix-engine-toolkit/src/model/value/metadata/bridge.rs
@@ -1,0 +1,125 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::model::address::{Bech32Coder, NetworkAwareNodeId};
+
+use super::{MetadataEntry, MetadataValue, MetadataValueConversionError};
+use scrypto::api::node_modules::metadata::{
+    MetadataEntry as NativeMetadataEntry, MetadataValue as NativeMetadataValue, Url,
+};
+use scrypto::prelude::*;
+
+impl MetadataEntry {
+    pub fn to_metadata_entry(
+        &self,
+        bech32_coder: &Bech32Coder,
+    ) -> Result<NativeMetadataEntry, MetadataValueConversionError> {
+        match self {
+            Self::List(entries) => entries
+                .iter()
+                .map(|entry| entry.to_metadata_value(bech32_coder))
+                .collect::<Result<_, _>>()
+                .map(NativeMetadataEntry::List),
+            Self::Value(entry) => entry
+                .to_metadata_value(bech32_coder)
+                .map(NativeMetadataEntry::Value),
+        }
+    }
+
+    pub fn from_metadata_entry(value: &NativeMetadataEntry, bech32_coder: &Bech32Coder) -> Self {
+        match value {
+            NativeMetadataEntry::List(entries) => Self::List(
+                entries
+                    .iter()
+                    .map(|entry| MetadataValue::from_metadata_value(entry, bech32_coder))
+                    .collect(),
+            ),
+            NativeMetadataEntry::Value(entry) => {
+                Self::Value(MetadataValue::from_metadata_value(entry, bech32_coder))
+            }
+        }
+    }
+}
+
+impl MetadataValue {
+    pub fn to_metadata_value(
+        &self,
+        bech32_coder: &Bech32Coder,
+    ) -> Result<NativeMetadataValue, MetadataValueConversionError> {
+        let value = match self {
+            Self::String { value } => NativeMetadataValue::String(value.to_owned()),
+            Self::Bool { value } => NativeMetadataValue::Bool(*value),
+            Self::U8 { value } => NativeMetadataValue::U8(*value),
+            Self::U32 { value } => NativeMetadataValue::U32(*value),
+            Self::U64 { value } => NativeMetadataValue::U64(*value),
+            Self::I32 { value } => NativeMetadataValue::I32(*value),
+            Self::I64 { value } => NativeMetadataValue::I64(*value),
+            Self::Decimal { value } => NativeMetadataValue::Decimal(value.to_owned()),
+            Self::Address { value } => {
+                NativeMetadataValue::Address(GlobalAddress::new_unchecked(value.0))
+            }
+            Self::PublicKey { value } => NativeMetadataValue::PublicKey(value.to_owned()),
+            Self::NonFungibleGlobalId { value } => {
+                NonFungibleGlobalId::try_from_canonical_string(bech32_coder.decoder(), value)
+                    .map(NativeMetadataValue::NonFungibleGlobalId)?
+            }
+            Self::NonFungibleLocalId { value } => {
+                NonFungibleLocalId::from_str(value).map(NativeMetadataValue::NonFungibleLocalId)?
+            }
+            Self::Instant { value } => NativeMetadataValue::Instant(Instant {
+                seconds_since_unix_epoch: *value,
+            }),
+            Self::Url { value } => NativeMetadataValue::Url(Url(value.to_owned())),
+        };
+        Ok(value)
+    }
+
+    pub fn from_metadata_value(value: &NativeMetadataValue, bech32_coder: &Bech32Coder) -> Self {
+        match value {
+            NativeMetadataValue::String(value) => Self::String {
+                value: value.to_owned(),
+            },
+            NativeMetadataValue::Bool(value) => Self::Bool { value: *value },
+            NativeMetadataValue::U8(value) => Self::U8 { value: *value },
+            NativeMetadataValue::U32(value) => Self::U32 { value: *value },
+            NativeMetadataValue::U64(value) => Self::U64 { value: *value },
+            NativeMetadataValue::I32(value) => Self::I32 { value: *value },
+            NativeMetadataValue::I64(value) => Self::I64 { value: *value },
+            NativeMetadataValue::Decimal(value) => Self::Decimal {
+                value: value.to_owned(),
+            },
+            NativeMetadataValue::Address(value) => Self::Address {
+                value: NetworkAwareNodeId(value.as_node_id().0, bech32_coder.network_id()),
+            },
+            NativeMetadataValue::PublicKey(value) => Self::PublicKey {
+                value: value.to_owned(),
+            },
+            NativeMetadataValue::NonFungibleGlobalId(value) => Self::NonFungibleGlobalId {
+                value: value.to_canonical_string(bech32_coder.encoder()),
+            },
+            NativeMetadataValue::NonFungibleLocalId(value) => Self::NonFungibleLocalId {
+                value: value.to_string(),
+            },
+            NativeMetadataValue::Instant(value) => Self::Instant {
+                value: value.seconds_since_unix_epoch,
+            },
+            NativeMetadataValue::Url(value) => Self::Url {
+                value: value.0.to_owned(),
+            },
+        }
+    }
+}

--- a/radix-engine-toolkit/src/model/value/metadata/error.rs
+++ b/radix-engine-toolkit/src/model/value/metadata/error.rs
@@ -15,8 +15,18 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod ast;
-pub mod macros;
-pub mod manifest_sbor;
-pub mod metadata;
-pub mod scrypto_sbor;
+use crate::impl_from_parse_error;
+
+pub enum MetadataValueConversionError {
+    /// An error emitted when trying to parse a string to a type fails.
+    ParseError { parsing: String, message: String },
+}
+
+impl_from_parse_error! {
+    MetadataValueConversionError,
+    scrypto::prelude::ParseNonFungibleLocalIdError => NonFungibleLocalId
+}
+impl_from_parse_error! {
+    MetadataValueConversionError,
+    scrypto::prelude::ParseNonFungibleGlobalIdError => NonFungibleGlobalId
+}

--- a/radix-engine-toolkit/src/model/value/metadata/mod.rs
+++ b/radix-engine-toolkit/src/model/value/metadata/mod.rs
@@ -15,8 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod ast;
-pub mod macros;
-pub mod manifest_sbor;
-pub mod metadata;
-pub mod scrypto_sbor;
+pub mod bridge;
+pub mod error;
+pub mod model;
+
+pub use bridge::*;
+pub use error::*;
+pub use model::*;

--- a/radix-engine-toolkit/src/model/value/metadata/model.rs
+++ b/radix-engine-toolkit/src/model/value/metadata/model.rs
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::model::address::NetworkAwareNodeId;
+use scrypto::prelude::*;
+use toolkit_derive::serializable;
+
+#[serializable]
+#[serde(tag = "type", content = "value")]
+#[derive(PartialEq, Eq)]
+pub enum MetadataEntry {
+    Value(MetadataValue),
+    List(Vec<MetadataValue>),
+}
+
+#[serializable]
+#[serde(tag = "type")]
+#[derive(PartialEq, Eq)]
+pub enum MetadataValue {
+    String {
+        value: String,
+    },
+
+    Bool {
+        value: bool,
+    },
+
+    U8 {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u8,
+    },
+
+    U32 {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u32,
+    },
+
+    U64 {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: u64,
+    },
+
+    I32 {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i32,
+    },
+
+    I64 {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i64,
+    },
+
+    Decimal {
+        #[schemars(regex(pattern = "[0-9]+"))]
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: Decimal,
+    },
+
+    Address {
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: NetworkAwareNodeId,
+    },
+
+    PublicKey {
+        #[schemars(with = "crate::model::crypto::PublicKey")]
+        #[serde_as(as = "serde_with::FromInto<crate::model::crypto::PublicKey>")]
+        value: PublicKey,
+    },
+
+    NonFungibleGlobalId {
+        value: String,
+    },
+
+    NonFungibleLocalId {
+        value: String,
+    },
+
+    Instant {
+        #[schemars(with = "String")]
+        #[serde_as(as = "serde_with::DisplayFromStr")]
+        value: i64,
+    },
+
+    Url {
+        value: String,
+    },
+}

--- a/radix-engine-toolkit/src/visitor/instruction/account_withdraws_visitor.rs
+++ b/radix-engine-toolkit/src/visitor/instruction/account_withdraws_visitor.rs
@@ -22,7 +22,7 @@ use scrypto::blueprints::account::*;
 use crate::error::VisitorError;
 use crate::model::address::utils::is_account;
 use crate::model::address::NetworkAwareNodeId;
-use crate::model::resource_specifier::ResourceSpecifier;
+use crate::model::resource_specifier::{ResourceManagerSpecifier, ResourceSpecifier};
 use crate::model::value::ast::{ManifestAstValue, ManifestAstValueKind};
 use crate::visitor::InstructionVisitor;
 use toolkit_derive::serializable;
@@ -82,7 +82,9 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                     *component_address,
                     ResourceSpecifier::Amount {
                         amount: amount.to_owned(),
-                        resource_address: *resource_address,
+                        resource_address: ResourceManagerSpecifier::Existing {
+                            address: *resource_address,
+                        },
                     },
                 )
             }
@@ -122,7 +124,9 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                     *component_address,
                     ResourceSpecifier::Ids {
                         ids,
-                        resource_address: *resource_address,
+                        resource_address: ResourceManagerSpecifier::Existing {
+                            address: *resource_address,
+                        },
                     },
                 )
             }
@@ -150,7 +154,9 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                     *component_address,
                     ResourceSpecifier::Amount {
                         amount: amount.to_owned(),
-                        resource_address: *resource_address,
+                        resource_address: ResourceManagerSpecifier::Existing {
+                            address: *resource_address,
+                        },
                     },
                 )
             }
@@ -191,7 +197,9 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                     *component_address,
                     ResourceSpecifier::Ids {
                         ids,
-                        resource_address: *resource_address,
+                        resource_address: ResourceManagerSpecifier::Existing {
+                            address: *resource_address,
+                        },
                     },
                 )
             }

--- a/radix-engine-toolkit/src/visitor/instruction/account_withdraws_visitor.rs
+++ b/radix-engine-toolkit/src/visitor/instruction/account_withdraws_visitor.rs
@@ -22,7 +22,7 @@ use scrypto::blueprints::account::*;
 use crate::error::VisitorError;
 use crate::model::address::utils::is_account;
 use crate::model::address::NetworkAwareNodeId;
-use crate::model::resource_specifier::{ResourceManagerSpecifier, ResourceSpecifier};
+use crate::model::resource_quantifier::{ResourceManagerSpecifier, ResourceQuantifier};
 use crate::model::value::ast::{ManifestAstValue, ManifestAstValueKind};
 use crate::visitor::InstructionVisitor;
 use toolkit_derive::serializable;
@@ -35,11 +35,11 @@ impl AccountWithdrawsInstructionVisitor {
     pub fn add(
         &mut self,
         component_address: NetworkAwareNodeId,
-        resource_specifier: ResourceSpecifier,
+        resource_quantifier: ResourceQuantifier,
     ) {
         self.0.push(AccountWithdraw {
             component_address,
-            resource_specifier,
+            resource_quantifier,
         });
     }
 }
@@ -80,7 +80,7 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
             {
                 self.add(
                     *component_address,
-                    ResourceSpecifier::Amount {
+                    ResourceQuantifier::Amount {
                         amount: amount.to_owned(),
                         resource_address: ResourceManagerSpecifier::Existing {
                             address: *resource_address,
@@ -122,7 +122,7 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                 };
                 self.add(
                     *component_address,
-                    ResourceSpecifier::Ids {
+                    ResourceQuantifier::Ids {
                         ids,
                         resource_address: ResourceManagerSpecifier::Existing {
                             address: *resource_address,
@@ -152,7 +152,7 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
             {
                 self.add(
                     *component_address,
-                    ResourceSpecifier::Amount {
+                    ResourceQuantifier::Amount {
                         amount: amount.to_owned(),
                         resource_address: ResourceManagerSpecifier::Existing {
                             address: *resource_address,
@@ -195,7 +195,7 @@ impl InstructionVisitor for AccountWithdrawsInstructionVisitor {
                 };
                 self.add(
                     *component_address,
-                    ResourceSpecifier::Ids {
+                    ResourceQuantifier::Ids {
                         ids,
                         resource_address: ResourceManagerSpecifier::Existing {
                             address: *resource_address,
@@ -222,5 +222,5 @@ pub struct AccountWithdraw {
     ///
     /// When this vector has more than one item, it means that multiple instructions performed a
     /// withdraw from the same account of the same resource.
-    resource_specifier: ResourceSpecifier,
+    resource_quantifier: ResourceQuantifier,
 }

--- a/radix-engine-toolkit/tests/analyze_transaction_execution.rs
+++ b/radix-engine-toolkit/tests/analyze_transaction_execution.rs
@@ -1,0 +1,123 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::collections::BTreeMap;
+
+use native_transaction::{builder::ManifestBuilder, manifest::decompile};
+use radix_engine::types::NetworkDefinition;
+use radix_engine_toolkit::{
+    functions::{analyze_transaction_execution, InvocationHandler},
+    model::{
+        resource_specifier::{ResourceManagerSpecifier, ResourceSpecifier},
+        transaction::{InstructionList, TransactionManifest},
+    },
+    visitor::{AccountDeposit, ExactnessSpecifier},
+};
+use scrypto::prelude::*;
+use scrypto_unit::TestRunner;
+
+#[test]
+pub fn analyze_create_resources_transaction() {
+    // Arrange
+    let mut test_runner = TestRunner::builder().without_trace().build();
+    let (_, _, account) = test_runner.new_account(false);
+
+    let manifest = ManifestBuilder::new()
+        .lock_fee(test_runner.faucet_component(), 10.into())
+        .create_fungible_resource(
+            18,
+            [
+                ("name".into(), "my first resource".into()),
+                ("description".into(), "my exciting resource".into()),
+            ]
+            .into(),
+            BTreeMap::<ResourceMethodAuthKey, (AccessRule, AccessRule)>::new(),
+            Some(1.into()),
+        )
+        .create_fungible_resource(
+            18,
+            [
+                ("name".into(), "my second resource".into()),
+                ("description".into(), "my exciting resource".into()),
+            ]
+            .into(),
+            BTreeMap::<ResourceMethodAuthKey, (AccessRule, AccessRule)>::new(),
+            Some(2.into()),
+        )
+        .call_method(
+            account,
+            "deposit_batch",
+            manifest_args!(ManifestExpression::EntireWorktop),
+        )
+        .build();
+
+    let receipt = test_runner.execute_manifest(manifest.clone(), vec![]);
+    receipt.expect_commit_success();
+
+    // Act
+    let manifest = TransactionManifest {
+        instructions: InstructionList::String(
+            decompile(&manifest.instructions, &NetworkDefinition::simulator()).unwrap(),
+        ),
+        blobs: Default::default(),
+    };
+    let output =
+        analyze_transaction_execution::Handler::fulfill(analyze_transaction_execution::Input {
+            network_id: 0xf2,
+            manifest,
+            transaction_receipt: scrypto_encode(&receipt).unwrap(),
+        });
+
+    // Assert
+    let output = output.expect("Should not fail");
+    assert_eq!(output.created_entities.resource_addresses.len(), 2);
+    assert_eq!(
+        output.account_deposits[0],
+        AccountDeposit {
+            component_address: as_network_aware_node_id!(account),
+            // TODO: This should be exact and not an estimate.
+            deposited: ExactnessSpecifier::Estimate {
+                instruction_index: 3,
+                resource_specifier: ResourceSpecifier::Amount {
+                    resource_address: ResourceManagerSpecifier::NewlyCreated { index: 1 },
+                    amount: 2.into()
+                }
+            }
+        }
+    );
+    assert_eq!(
+        output.account_deposits[1],
+        AccountDeposit {
+            component_address: as_network_aware_node_id!(account),
+            // TODO: This should be exact and not an estimate.
+            deposited: ExactnessSpecifier::Estimate {
+                instruction_index: 3,
+                resource_specifier: ResourceSpecifier::Amount {
+                    resource_address: ResourceManagerSpecifier::NewlyCreated { index: 0 },
+                    amount: 1.into()
+                }
+            }
+        }
+    );
+}
+
+#[macro_export]
+macro_rules! as_network_aware_node_id {
+    ($value: expr) => {
+        radix_engine_toolkit::model::address::NetworkAwareNodeId($value.as_node_id().0, 0xf2)
+    };
+}

--- a/radix-engine-toolkit/tests/analyze_transaction_execution.rs
+++ b/radix-engine-toolkit/tests/analyze_transaction_execution.rs
@@ -84,7 +84,7 @@ pub fn analyze_create_resources_transaction() {
 
     // Assert
     let output = output.expect("Should not fail");
-    assert_eq!(output.created_entities.resource_addresses.len(), 2);
+    assert_eq!(output.newly_created.resources.len(), 2);
     assert_eq!(
         output.account_deposits[0],
         AccountDeposit {

--- a/radix-engine-toolkit/tests/analyze_transaction_execution.rs
+++ b/radix-engine-toolkit/tests/analyze_transaction_execution.rs
@@ -22,7 +22,7 @@ use radix_engine::types::NetworkDefinition;
 use radix_engine_toolkit::{
     functions::{analyze_transaction_execution, InvocationHandler},
     model::{
-        resource_specifier::{ResourceManagerSpecifier, ResourceSpecifier},
+        resource_quantifier::{ResourceManagerSpecifier, ResourceQuantifier},
         transaction::{InstructionList, TransactionManifest},
     },
     visitor::{AccountDeposit, ExactnessSpecifier},
@@ -92,7 +92,7 @@ pub fn analyze_create_resources_transaction() {
             // TODO: This should be exact and not an estimate.
             deposited: ExactnessSpecifier::Estimate {
                 instruction_index: 3,
-                resource_specifier: ResourceSpecifier::Amount {
+                resource_quantifier: ResourceQuantifier::Amount {
                     resource_address: ResourceManagerSpecifier::NewlyCreated { index: 1 },
                     amount: 2.into()
                 }
@@ -106,7 +106,7 @@ pub fn analyze_create_resources_transaction() {
             // TODO: This should be exact and not an estimate.
             deposited: ExactnessSpecifier::Estimate {
                 instruction_index: 3,
-                resource_specifier: ResourceSpecifier::Amount {
+                resource_quantifier: ResourceQuantifier::Amount {
                     resource_address: ResourceManagerSpecifier::NewlyCreated { index: 0 },
                     amount: 1.into()
                 }

--- a/radix-engine-toolkit/tests/analyze_transaction_execution.rs
+++ b/radix-engine-toolkit/tests/analyze_transaction_execution.rs
@@ -25,7 +25,7 @@ use radix_engine_toolkit::{
         resource_quantifier::{ResourceManagerSpecifier, ResourceQuantifier},
         transaction::{InstructionList, TransactionManifest},
     },
-    visitor::{AccountDeposit, ExactnessSpecifier},
+    visitor::{AccountDeposit, ResourceSpecifier},
 };
 use scrypto::prelude::*;
 use scrypto_unit::TestRunner;
@@ -90,7 +90,7 @@ pub fn analyze_create_resources_transaction() {
         AccountDeposit {
             component_address: as_network_aware_node_id!(account),
             // TODO: This should be exact and not an estimate.
-            deposited: ExactnessSpecifier::Estimate {
+            deposited: ResourceSpecifier::Predicted {
                 instruction_index: 3,
                 resource_quantifier: ResourceQuantifier::Amount {
                     resource_address: ResourceManagerSpecifier::NewlyCreated { index: 1 },
@@ -104,7 +104,7 @@ pub fn analyze_create_resources_transaction() {
         AccountDeposit {
             component_address: as_network_aware_node_id!(account),
             // TODO: This should be exact and not an estimate.
-            deposited: ExactnessSpecifier::Estimate {
+            deposited: ResourceSpecifier::Predicted {
                 instruction_index: 3,
                 resource_quantifier: ResourceQuantifier::Amount {
                     resource_address: ResourceManagerSpecifier::NewlyCreated { index: 0 },

--- a/schema/out/schema/analyze_transaction_execution/Output.json
+++ b/schema/out/schema/analyze_transaction_execution/Output.json
@@ -8,8 +8,8 @@
     "account_proof_resources",
     "account_withdraws",
     "accounts_requiring_auth",
-    "created_entities",
-    "encountered_addresses"
+    "encountered_addresses",
+    "newly_created"
   ],
   "properties": {
     "encountered_addresses": {
@@ -50,11 +50,11 @@
         "$ref": "#/definitions/AccountDeposit"
       }
     },
-    "created_entities": {
+    "newly_created": {
       "description": "The set of entities which were newly created in this transaction.",
       "allOf": [
         {
-          "$ref": "#/definitions/CreatedEntities"
+          "$ref": "#/definitions/NewlyCreated"
         }
       ]
     }
@@ -418,7 +418,7 @@
             "type": {
               "type": "string",
               "enum": [
-                "Exact"
+                "Guaranteed"
               ]
             },
             "resource_quantifier": {
@@ -442,7 +442,7 @@
             "type": {
               "type": "string",
               "enum": [
-                "Estimate"
+                "Predicted"
               ]
             },
             "instruction_index": {
@@ -470,40 +470,415 @@
         }
       }
     },
-    "CreatedEntities": {
+    "NewlyCreated": {
       "description": "The set of newly created entities",
       "type": "object",
       "required": [
-        "component_addresses",
-        "package_addresses",
-        "resource_addresses"
+        "resources"
       ],
       "properties": {
-        "component_addresses": {
-          "description": "The set of addresses of newly created components.",
+        "resources": {
           "type": "array",
           "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "resource_addresses": {
-          "description": "The set of addresses of newly created resources.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "package_addresses": {
-          "description": "The set of addresses of newly created packages.",
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
+            "$ref": "#/definitions/NewlyCreatedResource"
+          }
         }
       }
+    },
+    "NewlyCreatedResource": {
+      "type": "object",
+      "required": [
+        "metadata"
+      ],
+      "properties": {
+        "metadata": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/MetadataKeyValue"
+          }
+        }
+      }
+    },
+    "MetadataKeyValue": {
+      "type": "object",
+      "required": [
+        "key",
+        "value"
+      ],
+      "properties": {
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/MetadataEntry"
+        }
+      }
+    },
+    "MetadataEntry": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Value"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/MetadataValue"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "List"
+              ]
+            },
+            "value": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/MetadataValue"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "MetadataValue": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "String"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Bool"
+              ]
+            },
+            "value": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "U8"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "U32"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "U64"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "I32"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "I64"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Decimal"
+              ]
+            },
+            "value": {
+              "type": "string",
+              "pattern": "[0-9]+"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Address"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "PublicKey"
+              ]
+            },
+            "value": {
+              "$ref": "#/definitions/PublicKey"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "NonFungibleGlobalId"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "NonFungibleLocalId"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Instant"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "value"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Url"
+              ]
+            },
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "PublicKey": {
+      "description": "A discriminated union of the possible public keys used by Scrypto and the Radix Engine.",
+      "oneOf": [
+        {
+          "description": "A byte array of 33 bytes which are serialized as a 66 character long hex-encoded string representing a public key from the ECDSA Secp256k1 elliptic curve.",
+          "examples": [
+            {
+              "curve": "EcdsaSecp256k1",
+              "public_key": "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "curve",
+            "public_key"
+          ],
+          "properties": {
+            "curve": {
+              "type": "string",
+              "enum": [
+                "EcdsaSecp256k1"
+              ]
+            },
+            "public_key": {
+              "type": "string",
+              "maxLength": 66,
+              "minLength": 66,
+              "pattern": "[0-9a-fA-F]+"
+            }
+          }
+        },
+        {
+          "description": "A byte array of 32 bytes which are serialized as a 64 character long hex-encoded string representing a public key from the EDDSA Ed25519 edwards curve.",
+          "examples": [
+            {
+              "curve": "EddsaEd25519",
+              "public_key": "4cb5abf6ad79fbf5abbccafcc269d85cd2651ed4b885b5869f241aedf0a5ba29"
+            }
+          ],
+          "type": "object",
+          "required": [
+            "curve",
+            "public_key"
+          ],
+          "properties": {
+            "curve": {
+              "type": "string",
+              "enum": [
+                "EddsaEd25519"
+              ]
+            },
+            "public_key": {
+              "type": "string",
+              "maxLength": 66,
+              "minLength": 66,
+              "pattern": "[0-9a-fA-F]+"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/schema/out/schema/analyze_transaction_execution/Output.json
+++ b/schema/out/schema/analyze_transaction_execution/Output.json
@@ -170,24 +170,24 @@
       "type": "object",
       "required": [
         "component_address",
-        "resource_specifier"
+        "resource_quantifier"
       ],
       "properties": {
         "component_address": {
           "description": "The component address of the account that the resources were withdrawn from.",
           "type": "string"
         },
-        "resource_specifier": {
+        "resource_quantifier": {
           "description": "A specifier used to specify what was withdrawn from the account - this could either be an amount or a set of non-fungible local ids.\n\nWhen this vector has more than one item, it means that multiple instructions performed a withdraw from the same account of the same resource.",
           "allOf": [
             {
-              "$ref": "#/definitions/ResourceSpecifier"
+              "$ref": "#/definitions/ResourceQuantifier"
             }
           ]
         }
       }
     },
-    "ResourceSpecifier": {
+    "ResourceQuantifier": {
       "description": "Specifies resources either through amounts for fungible and non-fungible resources or through ids for non-fungible resources.",
       "oneOf": [
         {
@@ -205,8 +205,12 @@
               ]
             },
             "resource_address": {
-              "description": "The resource address associated with the resource",
-              "type": "string"
+              "description": "A specifier of the resource manager, can either be an address for already existing resource managers or an index for newly created resource managers that can not be queried through the network gateway.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResourceManagerSpecifier"
+                }
+              ]
             },
             "amount": {
               "description": "The amount of resources withdrawn from the account. This is a decimal value which is serialized as a string.",
@@ -230,8 +234,12 @@
               ]
             },
             "resource_address": {
-              "description": "The resource address associated with the resource",
-              "type": "string"
+              "description": "A specifier of the resource manager, can either be an address for already existing resource managers or an index for newly created resource managers that can not be queried through the network gateway.",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/ResourceManagerSpecifier"
+                }
+              ]
             },
             "ids": {
               "description": "The set of non-fungible ids",
@@ -240,6 +248,46 @@
                 "$ref": "#/definitions/NonFungibleLocalId"
               },
               "uniqueItems": true
+            }
+          }
+        }
+      ]
+    },
+    "ResourceManagerSpecifier": {
+      "oneOf": [
+        {
+          "type": "object",
+          "required": [
+            "address",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Existing"
+              ]
+            },
+            "address": {
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "index",
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "NewlyCreated"
+              ]
+            },
+            "index": {
+              "type": "string"
             }
           }
         }
@@ -363,7 +411,7 @@
         {
           "type": "object",
           "required": [
-            "resource_specifier",
+            "resource_quantifier",
             "type"
           ],
           "properties": {
@@ -373,11 +421,11 @@
                 "Exact"
               ]
             },
-            "resource_specifier": {
+            "resource_quantifier": {
               "description": "A specifier of the amount or ids of resources.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/ResourceSpecifier"
+                  "$ref": "#/definitions/ResourceQuantifier"
                 }
               ]
             }
@@ -387,7 +435,7 @@
           "type": "object",
           "required": [
             "instruction_index",
-            "resource_specifier",
+            "resource_quantifier",
             "type"
           ],
           "properties": {
@@ -402,11 +450,11 @@
               "type": "string",
               "pattern": "[0-9]+"
             },
-            "resource_specifier": {
+            "resource_quantifier": {
               "description": "A specifier of the amount or ids of resources.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/ResourceSpecifier"
+                  "$ref": "#/definitions/ResourceQuantifier"
                 }
               ]
             }


### PR DESCRIPTION
# Background

This PR makes a number of big changes to the `analyze_transaction_execution` function in the Radix Engine Toolkit. 

Previously, The Radix Engine Toolkit had an issue where it surfaced the resource addresses of newly created resources with deposits. Since the wallet uses this function with transaction preview receipts to add guarantees, it meant that the wallet was adding guarantees for resources which didn't yet exist and whose resource addresses were subject to change. 

With this PR, the toolkit no longer returns the resource addresses of newly created resources. Instead, it refers to newly created resources through an index. This means that the wallet should never have a handle on a resource address from the toolkit which does not yet exist. In other words, wallet, if you see a resource address, you can do Gateway queries for it, no need to check it against the array of newly created addresses.

Additionally, the toolkit now returns the Metadata of newly created resources since that metadata may not be queried from the gateway if a transaction preview receipt is provided by the wallet.

Here is an example manifest and the output produced:

## Manifest

```ruby
CALL_METHOD
    Address("component_sim1pyakxvzls3cwkfp25xz7dufp9jnw6wzxe3cxaku2ju7tlyuvusk6y9")
    "lock_fee"
    Decimal("10");
CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
    18u8
    Map<String, String>("description", "my exciting resource", "name", "my first resource")
    Map<Enum, Tuple>()
    Decimal("1");
CREATE_FUNGIBLE_RESOURCE_WITH_INITIAL_SUPPLY
    18u8
    Map<String, String>("description", "my exciting resource", "name", "my second resource")
    Map<Enum, Tuple>()
    Decimal("2");
CALL_METHOD
    Address("account_sim1ql02qtc2tm73h5dyl8grh2p8xfncgrfltagjm7adlg3edr0ejjmpvt")
    "deposit_batch"
    Expression("ENTIRE_WORKTOP");
```

## Output

```json
{
  "encountered_addresses": {
    "component_addresses": {
      "user_applications": [
        "component_sim1pyakxvzls3cwkfp25xz7dufp9jnw6wzxe3cxaku2ju7tlyuvusk6y9"
      ],
      "accounts": [
        "account_sim1ql02qtc2tm73h5dyl8grh2p8xfncgrfltagjm7adlg3edr0ejjmpvt"
      ],
      "identities": [],
      "clocks": [],
      "epoch_managers": [],
      "validators": [],
      "access_controller": []
    },
    "resource_addresses": [],
    "package_addresses": []
  },
  "accounts_requiring_auth": [],
  "account_proof_resources": [],
  "account_withdraws": [],
  "account_deposits": [
    {
      "component_address": "account_sim1ql02qtc2tm73h5dyl8grh2p8xfncgrfltagjm7adlg3edr0ejjmpvt",
      "type": "Predicted",
      "instruction_index": "3",
      "resource_quantifier": {
        "type": "Amount",
        "resource_address": {
          "type": "NewlyCreated",
          "index": "1"
        },
        "amount": "2"
      }
    },
    {
      "component_address": "account_sim1ql02qtc2tm73h5dyl8grh2p8xfncgrfltagjm7adlg3edr0ejjmpvt",
      "type": "Predicted",
      "instruction_index": "3",
      "resource_quantifier": {
        "type": "Amount",
        "resource_address": {
          "type": "NewlyCreated",
          "index": "0"
        },
        "amount": "1"
      }
    }
  ],
  "newly_created": {
    "resources": [
      {
        "metadata": [
          {
            "key": "name",
            "value": {
              "type": "Value",
              "value": {
                "type": "String",
                "value": "my first resource"
              }
            }
          },
          {
            "key": "description",
            "value": {
              "type": "Value",
              "value": {
                "type": "String",
                "value": "my exciting resource"
              }
            }
          }
        ]
      },
      {
        "metadata": [
          {
            "key": "name",
            "value": {
              "type": "Value",
              "value": {
                "type": "String",
                "value": "my second resource"
              }
            }
          },
          {
            "key": "description",
            "value": {
              "type": "Value",
              "value": {
                "type": "String",
                "value": "my exciting resource"
              }
            }
          }
        ]
      }
    ]
  }
}
```

In the above JSON, pay attention to the following bit:

```json
"resource_quantifier": {
    "type": "Amount",
    "resource_address": {
        "type": "NewlyCreated",
        "index": "0"
    },
    "amount": "1"
}
```

Notice that a newly created resource is no longer referred to through it's resource address (since it doesn't exist). Instead, it is referred to through its index. At this index, in the `output.newly_created.resources` you may find the resource metadata.

# Change Log

- The `analyze_transaction_execution` function output contained a `ResourceSpecifier` nested inside of it where the `resource_address` used to be a `String`. With this change, `resource_address` is no longer a string and is a `ResourceManagerSpecifier` which can either refer to an existing resource or a newly created resource. Please refer to the JSON Schema for more information on the structure of this object.
    - Previously, the wallet needed to first check if a resource address was in the list of newly created resources or not before querying the gateway API for its metadata. This will no longer be the case, if you have a valid resource address (`ResourceManagerSpecifier::Existing`), you can query the gateway and trust that you will get a response. Otherwise, if you have a `ResourceManagerSpecifier::NewlyCreated`, then you do not have the address and only have the index; thus you can’t query the gateway.
- Added a new section to the output called the `newly_created` section which currently contains the metadata of newly created resources.
- Removed the created_entities section of the output of the analyze_transaction_execution function in favor of a more detailed output for each for different entities.
- Renamed `resource_specifier` to `resource_quantifier`.
- Renamed `Exact` to `Guaranteed` and `Estimated` to `Predicted`.
- Added a new `MetadataValue` and `MetadataEntry` models which are used for the metadata returned from this function. 