### PR TITLE
SPM deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,8 @@ jobs:
 
 
           echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
-          if git ls-remote --heads $REMOTE_REPO $BRANCH_NAME | grep $BRANCH_NAME; then
+          REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
+          if [ -z "$REMOTE_BRANCH"] then
             git fetch origin $BRANCH
             git checkout $BRANCH
             git pull origin $BRANCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,6 @@ on:
       - feature/*
       - develop
       - main
-  pull_request:
-    branches:
-      - release/*
-      - feature/*
-      - develop
-      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,6 @@ on:
       - feature/*
       - develop
       - main
-      - spm_deploy
   pull_request:
     branches:
       - release/*
@@ -48,6 +47,46 @@ jobs:
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit
+            target-triple: x86_64-pc-windows-gnu
+            custom-linker: ""
+            custom-compiler: x86_64-w64-mingw32-gcc
+            custom-archiver: x86_64-w64-mingw32-ar
+          - crate: radix-engine-toolkit
+            target-triple: x86_64-unknown-linux-gnu
+            custom-linker: x86_64-unknown-linux-gnu-gcc
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit
+            target-triple: aarch64-unknown-linux-gnu
+            custom-linker: aarch64-unknown-linux-gnu-gcc
+            custom-compiler: aarch64-unknown-linux-gnu-gcc
+            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit
+            target-triple: i686-unknown-linux-gnu
+            custom-linker: i686-unknown-linux-gnu-gcc
+            custom-compiler: i686-unknown-linux-gnu-gcc
+            custom-archiver: i686-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit
+            target-triple: wasm32-unknown-unknown
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit
+            target-triple: aarch64-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit
+            target-triple: armv7-linux-androideabi
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit
+            target-triple: i686-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
           # radix-engine-toolkit-uniffi Crate
           - crate: radix-engine-toolkit-uniffi
             target-triple: aarch64-apple-darwin
@@ -74,6 +113,41 @@ jobs:
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-pc-windows-gnu
+            custom-linker: ""
+            custom-compiler: x86_64-w64-mingw32-gcc
+            custom-archiver: x86_64-w64-mingw32-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-unknown-linux-gnu
+            custom-linker: x86_64-unknown-linux-gnu-gcc
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-unknown-linux-gnu
+            custom-linker: aarch64-unknown-linux-gnu-gcc
+            custom-compiler: aarch64-unknown-linux-gnu-gcc
+            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: i686-unknown-linux-gnu
+            custom-linker: i686-unknown-linux-gnu-gcc
+            custom-compiler: i686-unknown-linux-gnu-gcc
+            custom-archiver: i686-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: armv7-linux-androideabi
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: i686-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
 
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,11 @@ jobs:
       - name: "Clone spm repo"
         env:
           BRANCH: ${{env.GITHUB_REF_NAME}}
+          GIT_USER: ${{ secrets.RADIX_BOT_USERNAME }}
         run: |
               echo "deploying on branch $BRANCH"
+              git config user.name $GIT_USER
+              git config user.email $GIT_USER
               # Push changes to Swift Engine Toolkit
               SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
               git clone $SWIFT_ENGINE_TOOLKIT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,8 +35,18 @@ jobs:
           CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
           SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
+          SET_UPSTREAM_FLAG=""
 
-          git checkout $BRANCH || git checkout -b $BRANCH
+          if git show-ref --verify --quiet "refs/remotes/origin/spm_deploy"; then
+            git fetch origin $BRANCH
+            git checkout $BRANCH
+            git pull origin $BRANCH
+          else
+            git checkout -b $BRANCH
+            # Allows creating branch on remote
+            SET_UPSTREAM_FLAG="-u"
+          fi
+
           touch dummy.txt
           #  cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
           # cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
@@ -44,9 +54,7 @@ jobs:
           git add .
           git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
           git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
-          # Allow creating branch if missing
-          git config --global --add --bool push.autoSetupRemote true
-          git push
+          git push $SET_UPSTREAM_FLAG origin $BRANCH
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           BRANCH: ${{env.GITHUB_REF}}
         run: |
           echo "Branch name: $BRANCH"
-          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | grep -o '"version": *"[^"]*"' | grep -o '"[^"]*"$')
+          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | jq -r 'version')
           echo "Crate version: $VERSION"
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
           SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
           SET_UPSTREAM_FLAG=""
 
-          if git show-ref --verify --quiet "refs/remotes/origin/spm_deploy"; then
+
+          echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
+          if git ls-remote --heads $REMOTE_REPO $BRANCH_NAME | grep $BRANCH_NAME; then
             git fetch origin $BRANCH
             git checkout $BRANCH
             git pull origin $BRANCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Checkout Swift Engine toolkit
+        uses: actions/checkout@v3
+        with:
+           repository: radixdlt/swift-engine-toolkit
+           token: ${{ secrets.RADIX_BOT_PAT }}
+           path: ./swift-engine-toolkit
       - name: Branch abd version
+        working-directory: swift-engine-toolkit
         run: |
           BRANCH=${{ github.ref_name }}
-          echo "Branch name: $BRANCH"
-          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | jq -r '.version')
+          BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
+          CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          echo "Crate version: $VERSION.$LAST_COMMIT_SHA"
+          SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
+
+          git checkout $BRANCH || git checkout -b $BRANCH
+          git touch dummy.txt
+          #  cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
+          # cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
+
+          git add .
+          git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
+          git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
+          git push || git push --set-upstream origin $BRANCH
 
   build:
     runs-on: macos-latest
@@ -320,17 +337,22 @@ jobs:
 
       - name: Publish to Swift Engine Toolkit
         working-directory: swift-engine-toolkit
-        env:
-          BRANCH: ${{env.GITHUB_REF_NAME}}
         run: |
+          BRANCH=${{ github.ref_name }}
+          BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
+          CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
+          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
+          SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
+
           git checkout $BRANCH || git checkout -b $BRANCH
           cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
           cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
 
-          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
           git add .
-          git commit -m "Update RET from $LAST_COMMIT_SHA"
+          git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
+          git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
           git push || git push --set-upstream origin $BRANCH
+
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,13 @@ jobs:
           BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
           CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
+          SPM_VERSION="$CRATE_VERSION-$LAST_COMMIT_SHA"
           SET_UPSTREAM_FLAG=""
 
 
           echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
           REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
-          if [ -z "$REMOTE_BRANCH"]
+          if [ -z "$REMOTE_BRANCH" ]
           then
             git fetch origin $BRANCH
             git checkout $BRANCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,8 @@ jobs:
         run: |
           cd swift-engine-toolkit
           touch emptyFile.txt
-          git commit -am "test commit"
+          git add .
+          git commit -m "test commit"
           git push
              #- name: "Clone spm repo"
              # env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,20 @@ on:
       - main
 
 jobs:
+  spm_clone:
+    runs-on: macos-latest
+    env:
+      BRANCH: ${{env.GITHUB_REF_NAME}}
+    run: |
+          echo "deploying on branch $BRANCH"
+          # Push changes to Swift Engine Toolkit
+          SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
+          git clone $SWIFT_ENGINE_TOOLKIT
+          cd swift-engine-toolkit
+          git checkout $BRANCH || git checkout -b $BRANCH
+
   build:
+    needs: [spm_clone]
     runs-on: macos-latest
     continue-on-error: true
     strategy:
@@ -367,19 +380,13 @@ jobs:
               -headers "./$EXTRACTED/include" \
               -output "./$EXTRACTED/RadixEngineToolkitUniFFI.xcframework"
 
-          # Push changes to Swift Engine Toolkit
-          SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
-          git clone $SWIFT_ENGINE_TOOLKIT
-          git checkout $BRANCH || git checkout -b $BRANCH
 
-          cd swift-engine-toolkit
-          git checkout -b $BRANCH_NAME
-          cp -R ../$EXTRACTED/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkit/RadixEngineToolkitUniFFI.xcframework
-          cp -R ../$EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkit/radix_engine_toolkit_uniffi
+          #cp -R ../$EXTRACTED/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkit/RadixEngineToolkitUniFFI.xcframework
+          #cp -R ../$EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkit/radix_engine_toolkit_uniffi
 
-          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          git commit -am "Update RET from $LAST_COMMIT_SHA"
-          git push origin -b $BRANCH_NAME
+          #LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
+          #git commit -am "Update RET from $LAST_COMMIT_SHA"
+          #git push origin -b $BRANCH_NAME
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,9 @@ jobs:
           git add .
           git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
           git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
-          git push || git push --set-upstream origin $BRANCH
+          # Allow creating branch if missing
+          git config --global --add --bool push.autoSetupRemote true
+          git push
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,10 +243,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artifacts
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: "14.3.1"
-
       - name: Build XCFramework
         working-directory: artifacts
         env:
@@ -294,9 +290,9 @@ jobs:
               -o "./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib"
 
           # Set proper id, so that Xcode can properly locate the dynamic library
-          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/aarch64-apple-ios/libradix_engine_toolkit_uniffi.dylib
-          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
-          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
+          install_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/aarch64-apple-ios/libradix_engine_toolkit_uniffi.dylib
+          install_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
+          install_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
 
           # Creating the XCFramework
           xcodebuild -create-xcframework \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           BRANCH: ${{env.GITHUB_REF}}
         run: |
           echo "Branch name: $BRANCH"
-          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | jq -r 'version')
+          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | jq -r '.version')
           echo "Crate version: $VERSION"
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,8 @@ jobs:
 
           echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
           REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
-          if [ -z "$REMOTE_BRANCH"] then
+          if [ -z "$REMOTE_BRANCH"]
+          then
             git fetch origin $BRANCH
             git checkout $BRANCH
             git pull origin $BRANCH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,42 +16,7 @@ on:
       - main
 
 jobs:
-  spm_clone:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Checkout Swift Egine toolkit
-        uses: actions/checkout@v3
-        with:
-           repository: radixdlt/swift-engine-toolkit
-           token: ${{ secrets.RADIX_BOT_PAT }}
-           path: ./swift-engine-toolkit
-      - name: Push trivial file
-        run: |
-          cd swift-engine-toolkit
-          touch emptyFile.txt
-          git add .
-          git commit -m "test commit"
-          git push
-             #- name: "Clone spm repo"
-             # env:
-             #BRANCH: ${{env.GITHUB_REF_NAME}}
-             #GIT_USER: ${{ secrets.RADIX_BOT_USERNAME }}
-             #GIT_TOKEN: ${{ secrets.RADIX_BOT_PAT }}
-             #run: |
-             #echo "deploying on branch $BRANCH"
-             # git config user.name $GIT_USER
-             # git config user.email $GIT_USER
-             # # Push changes to Swift Engine Toolkit
-             # SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
-             # git clone $SWIFT_ENGINE_TOOLKIT
-
-             # cd swift-engine-toolkit
-             # git checkout $BRANCH || git checkout -b $BRANCH
-
   build:
-    needs: [spm_clone]
     runs-on: macos-latest
     continue-on-error: true
     strategy:
@@ -83,46 +48,6 @@ jobs:
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit
-            target-triple: x86_64-pc-windows-gnu
-            custom-linker: ""
-            custom-compiler: x86_64-w64-mingw32-gcc
-            custom-archiver: x86_64-w64-mingw32-ar
-          - crate: radix-engine-toolkit
-            target-triple: x86_64-unknown-linux-gnu
-            custom-linker: x86_64-unknown-linux-gnu-gcc
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit
-            target-triple: aarch64-unknown-linux-gnu
-            custom-linker: aarch64-unknown-linux-gnu-gcc
-            custom-compiler: aarch64-unknown-linux-gnu-gcc
-            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit
-            target-triple: i686-unknown-linux-gnu
-            custom-linker: i686-unknown-linux-gnu-gcc
-            custom-compiler: i686-unknown-linux-gnu-gcc
-            custom-archiver: i686-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit
-            target-triple: wasm32-unknown-unknown
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit
-            target-triple: aarch64-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit
-            target-triple: armv7-linux-androideabi
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit
-            target-triple: i686-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
           # radix-engine-toolkit-uniffi Crate
           - crate: radix-engine-toolkit-uniffi
             target-triple: aarch64-apple-darwin
@@ -149,41 +74,6 @@ jobs:
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-pc-windows-gnu
-            custom-linker: ""
-            custom-compiler: x86_64-w64-mingw32-gcc
-            custom-archiver: x86_64-w64-mingw32-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-unknown-linux-gnu
-            custom-linker: x86_64-unknown-linux-gnu-gcc
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-unknown-linux-gnu
-            custom-linker: aarch64-unknown-linux-gnu-gcc
-            custom-compiler: aarch64-unknown-linux-gnu-gcc
-            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: i686-unknown-linux-gnu
-            custom-linker: i686-unknown-linux-gnu-gcc
-            custom-compiler: i686-unknown-linux-gnu-gcc
-            custom-archiver: i686-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: armv7-linux-androideabi
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: i686-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
 
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2
@@ -344,6 +234,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Checkout Swift Egine toolkit
+        uses: actions/checkout@v3
+        with:
+           repository: radixdlt/swift-engine-toolkit
+           token: ${{ secrets.RADIX_BOT_PAT }}
+           path: ./swift-engine-toolkit
       - uses: actions/download-artifact@v3
         with:
           path: artifacts
@@ -403,13 +299,19 @@ jobs:
               -headers "./$EXTRACTED/include" \
               -output "./$EXTRACTED/RadixEngineToolkitUniFFI.xcframework"
 
+      - name: Publish to Swift Engine Toolkit
+        working-directory: artifacts
+        env:
+          BRANCH: ${{env.GITHUB_REF_NAME}}
+        run: |
+          git checkout $BRANCH || git checkout -b $BRANCH
+          cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkit/RadixEngineToolkitUniFFI.xcframework
+          cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkit/radix_engine_toolkit_uniffi
 
-          #cp -R ../$EXTRACTED/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkit/RadixEngineToolkitUniFFI.xcframework
-          #cp -R ../$EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkit/radix_engine_toolkit_uniffi
-
-          #LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          #git commit -am "Update RET from $LAST_COMMIT_SHA"
-          #git push origin -b $BRANCH_NAME
+          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
+          git add .
+          git commit -m "Update RET from $LAST_COMMIT_SHA"
+          git push || git push --set-upstream origin $BRANCH
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
 
           git checkout $BRANCH || git checkout -b $BRANCH
-          git touch dummy.txt
+          touch dummy.txt
           #  cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
           # cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,7 @@ jobs:
           git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
           git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
           git push $SET_UPSTREAM_FLAG origin $BRANCH
+          git push origin $SPM_VERSION
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,21 +21,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: "Clone spm repo"
-        env:
-          BRANCH: ${{env.GITHUB_REF_NAME}}
-          GIT_USER: ${{ secrets.RADIX_BOT_USERNAME }}
-          GIT_TOKEN: ${{ secrets.RADIX_BOT_PAT }}
-        run: |
-              echo "deploying on branch $BRANCH"
-              git config user.name $GIT_USER
-              git config user.email $GIT_USER
-              # Push changes to Swift Engine Toolkit
-              SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
-              git clone $SWIFT_ENGINE_TOOLKIT
+      - name: Checkout Swift Egine toolkit
+        uses: actions/checkout@v3
+        with:
+           repository: radixdlt/swift-engine-toolkit
+           token: ${{ secrets.RADIX_BOT_PAT }}
+           path: ./swift-engine-toolkit
+             #- name: "Clone spm repo"
+             # env:
+             #BRANCH: ${{env.GITHUB_REF_NAME}}
+             #GIT_USER: ${{ secrets.RADIX_BOT_USERNAME }}
+             #GIT_TOKEN: ${{ secrets.RADIX_BOT_PAT }}
+             #run: |
+             #echo "deploying on branch $BRANCH"
+             # git config user.name $GIT_USER
+             # git config user.email $GIT_USER
+             # # Push changes to Swift Engine Toolkit
+             # SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
+             # git clone $SWIFT_ENGINE_TOOLKIT
 
-              cd swift-engine-toolkit
-              git checkout $BRANCH || git checkout -b $BRANCH
+             # cd swift-engine-toolkit
+             # git checkout $BRANCH || git checkout -b $BRANCH
 
   build:
     needs: [spm_clone]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,22 @@ on:
       - main
 
 jobs:
+  version_test:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Branch abd version
+        env:
+          BRANCH: ${{env.GITHUB_REF_NAME}}
+        run: |
+          echo "Branch name: $BRANCH"
+          VERSION=$(cargo pkgid --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | cut -d "#" -f2)
+          echo "Crate version: $VERSION"
+
   build:
     runs-on: macos-latest
+    needs: [version_test]
     continue-on-error: true
     strategy:
       matrix:
@@ -311,7 +325,7 @@ jobs:
         run: |
           git checkout $BRANCH || git checkout -b $BRANCH
           cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
-          cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi
+          cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
 
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
           git add .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,8 +245,6 @@ jobs:
           path: artifacts
       - name: Build XCFramework
         working-directory: artifacts
-        env:
-          BRANCH: ${{env.GITHUB_REF_NAME}}
         run: |
           # The name of the crate that we will be creating the XCFramework and the bindings for.
           CRATE_NAME="radix-engine-toolkit-uniffi"
@@ -305,14 +303,15 @@ jobs:
               -output "./$EXTRACTED/RadixEngineToolkitUniFFI.xcframework"
 
       - name: Publish to Swift Engine Toolkit
-        working-directory: swift-engine-toolkit
         run: |
           BRANCH=${{ github.ref_name }}
-          BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
+          BUILD_CRATE_MANIFEST="./radix-engine-toolkit-uniffi/Cargo.toml"
           CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
           SPM_VERSION="$CRATE_VERSION-$LAST_COMMIT_SHA"
           SET_UPSTREAM_FLAG=""
+
+          cd swift-engine-toolkit
           REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
 
           if [ -z "$REMOTE_BRANCH" ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artifacts
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "14.3.1"
+
       - name: Build XCFramework
         working-directory: artifacts
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
 
           # Creating the include directory - this will be used in the XCFramework build steps
           mkdir $EXTRACTED/include
-          cp $EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffiFFI.modulemap $EXTRACTED/include/module.moduplemap
+          cp $EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffiFFI.modulemap $EXTRACTED/include/module.modulemap
           cp $EXTRACTED/UniFFI-Bindings/output/radix_engine_toolkit_uniffiFFI.h $EXTRACTED/include/radix_engine_toolkit_uniffiFFI.h
 
           # Extract the builds of the targets that we need. All of them have a common known pattern which
@@ -281,21 +281,26 @@ jobs:
           mkdir ./$EXTRACTED/ios-simulator-arm64_x86_64
 
           lipo -create \
-              "./$EXTRACTED/aarch64-apple-darwin/libradix_engine_toolkit_uniffi.a" \
-              "./$EXTRACTED/x86_64-apple-darwin/libradix_engine_toolkit_uniffi.a" \
-              -o "./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.a"
+              "./$EXTRACTED/aarch64-apple-darwin/libradix_engine_toolkit_uniffi.dylib" \
+              "./$EXTRACTED/x86_64-apple-darwin/libradix_engine_toolkit_uniffi.dylib" \
+              -o "./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib"
           lipo -create \
-              "./$EXTRACTED/aarch64-apple-ios-sim/libradix_engine_toolkit_uniffi.a" \
-              "./$EXTRACTED/x86_64-apple-ios/libradix_engine_toolkit_uniffi.a" \
-              -o "./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.a"
+              "./$EXTRACTED/aarch64-apple-ios-sim/libradix_engine_toolkit_uniffi.dylib" \
+              "./$EXTRACTED/x86_64-apple-ios/libradix_engine_toolkit_uniffi.dylib" \
+              -o "./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib"
+
+          # Set proper id, so that Xcode can properly locate the dynamic library
+          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/aarch64-apple-ios/libradix_engine_toolkit_uniffi.dylib
+          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
+          instal_name_tool -id @rpath/libradix_engine_toolkit_uniffi.dylib ./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib
 
           # Creating the XCFramework
           xcodebuild -create-xcframework \
-              -library "./$EXTRACTED/aarch64-apple-ios/libradix_engine_toolkit_uniffi.a" \
+              -library "./$EXTRACTED/aarch64-apple-ios/libradix_engine_toolkit_uniffi.dylib" \
               -headers "./$EXTRACTED/include" \
-              -library "./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.a" \
+              -library "./$EXTRACTED/macos-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib" \
               -headers "./$EXTRACTED/include" \
-              -library "./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.a" \
+              -library "./$EXTRACTED/ios-simulator-arm64_x86_64/libradix_engine_toolkit_uniffi.dylib" \
               -headers "./$EXTRACTED/include" \
               -output "./$EXTRACTED/RadixEngineToolkitUniFFI.xcframework"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,7 +300,7 @@ jobs:
               -output "./$EXTRACTED/RadixEngineToolkitUniFFI.xcframework"
 
       - name: Publish to Swift Engine Toolkit
-        working-directory: artifacts
+        working-directory: swift-engine-toolkit
         env:
           BRANCH: ${{env.GITHUB_REF_NAME}}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,20 +37,19 @@ jobs:
           SPM_VERSION="$CRATE_VERSION-$LAST_COMMIT_SHA"
           SET_UPSTREAM_FLAG=""
 
-
           echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
           REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
           if [ -z "$REMOTE_BRANCH" ]
           then
-            git fetch origin $BRANCH
-            git checkout $BRANCH
-            git pull origin $BRANCH
-            echo "Pulled latest branch state"
-          else
             git checkout -b $BRANCH
             # Allows creating branch on remote
             SET_UPSTREAM_FLAG="-u"
             echo "New branch"
+          else
+            git fetch origin $BRANCH
+            git checkout $BRANCH
+            git pull origin $BRANCH
+            echo "Pulled latest branch state"
           fi
 
           touch dummy.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
   spm_clone:
     runs-on: macos-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: "Clone spm repo"
         env:
           BRANCH: ${{env.GITHUB_REF_NAME}}
@@ -32,8 +34,8 @@ jobs:
               SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
               git clone $SWIFT_ENGINE_TOOLKIT
 
-              #cd swift-engine-toolkit
-              #git checkout $BRANCH || git checkout -b $BRANCH
+              cd swift-engine-toolkit
+              git checkout $BRANCH || git checkout -b $BRANCH
 
   build:
     needs: [spm_clone]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,8 +310,8 @@ jobs:
           BRANCH: ${{env.GITHUB_REF_NAME}}
         run: |
           git checkout $BRANCH || git checkout -b $BRANCH
-          cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkit/RadixEngineToolkitUniFFI.xcframework
-          cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkit/radix_engine_toolkit_uniffi
+          cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
+          cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi
 
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
           git add .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Branch abd version
-        env:
-          BRANCH: ${{env.GITHUB_REF}}
         run: |
+          BRANCH=${{ github.ref_name }}
           echo "Branch name: $BRANCH"
           VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | jq -r '.version')
-          echo "Crate version: $VERSION"
+          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
+          echo "Crate version: $VERSION.$LAST_COMMIT_SHA"
 
   build:
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,55 +16,8 @@ on:
       - main
 
 jobs:
-  version_test:
-    runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Checkout Swift Engine toolkit
-        uses: actions/checkout@v3
-        with:
-           repository: radixdlt/swift-engine-toolkit
-           token: ${{ secrets.RADIX_BOT_PAT }}
-           path: ./swift-engine-toolkit
-      - name: Branch abd version
-        working-directory: swift-engine-toolkit
-        run: |
-          BRANCH=${{ github.ref_name }}
-          BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
-          CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
-          LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          SPM_VERSION="$CRATE_VERSION-$LAST_COMMIT_SHA"
-          SET_UPSTREAM_FLAG=""
-
-          echo $(git ls-remote --heads origin $BRANCH | grep $BRANCH)
-          REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
-          if [ -z "$REMOTE_BRANCH" ]
-          then
-            git checkout -b $BRANCH
-            # Allows creating branch on remote
-            SET_UPSTREAM_FLAG="-u"
-            echo "New branch"
-          else
-            git fetch origin $BRANCH
-            git checkout $BRANCH
-            git pull origin $BRANCH
-            echo "Pulled latest branch state"
-          fi
-
-          touch dummy.txt
-          #  cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
-          # cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
-
-          git add .
-          git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
-          git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
-          git push $SET_UPSTREAM_FLAG origin $BRANCH
-          git push origin $SPM_VERSION
-
   build:
     runs-on: macos-latest
-    needs: [version_test]
     continue-on-error: true
     strategy:
       matrix:
@@ -358,17 +311,29 @@ jobs:
           BUILD_CRATE_MANIFEST="../radix-engine-toolkit-uniffi/Cargo.toml"
           CRATE_VERSION=$(cargo read-manifest --manifest-path $BUILD_CRATE_MANIFEST |  jq -r '.version')
           LAST_COMMIT_SHA=$(git rev-parse --short HEAD)
-          SPM_VERSION=$CRATE_VERSION.$LAST_COMMIT_SHA
+          SPM_VERSION="$CRATE_VERSION-$LAST_COMMIT_SHA"
+          SET_UPSTREAM_FLAG=""
+          REMOTE_BRANCH=$(git ls-remote --heads origin $BRANCH | grep $BRANCH)
 
-          git checkout $BRANCH || git checkout -b $BRANCH
+          if [ -z "$REMOTE_BRANCH" ]
+          then
+            git checkout -b $BRANCH
+            # Allows creating branch on remote
+            SET_UPSTREAM_FLAG="-u"
+          else
+            git fetch origin $BRANCH
+            git checkout $BRANCH
+            git pull origin $BRANCH
+          fi
+
           cp -R ../artifacts/extracted/RadixEngineToolkitUniFFI.xcframework ./Sources/RadixEngineToolkitUniFFI/RadixEngineToolkitUniFFI.xcframework
           cp -R ../artifacts/extracted/UniFFI-Bindings/output/radix_engine_toolkit_uniffi.swift ./Sources/EngineToolkitUniFFI/radix_engine_toolkit_uniffi.swift
 
           git add .
           git commit -m "Update RET from $BRANCH - $LAST_COMMIT_SHA"
           git tag -a $SPM_VERSION -m "RET update from $BRANCH - $LAST_COMMIT_SHA"
-          git push || git push --set-upstream origin $BRANCH
-
+          git push $SET_UPSTREAM_FLAG origin $BRANCH
+          git push origin $SPM_VERSION
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,10 +41,12 @@ jobs:
             git fetch origin $BRANCH
             git checkout $BRANCH
             git pull origin $BRANCH
+            echo "Pulled latest branch state"
           else
             git checkout -b $BRANCH
             # Allows creating branch on remote
             SET_UPSTREAM_FLAG="-u"
+            echo "New branch"
           fi
 
           touch dummy.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,12 @@ jobs:
            repository: radixdlt/swift-engine-toolkit
            token: ${{ secrets.RADIX_BOT_PAT }}
            path: ./swift-engine-toolkit
+      - name: Push trivial file
+        run: |
+          cd swift-engine-toolkit
+          touch emptyFile.txt
+          git commit -am "test commit"
+          git push
              #- name: "Clone spm repo"
              # env:
              #BRANCH: ${{env.GITHUB_REF_NAME}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - feature/*
       - develop
       - main
+      - spm_deploy
   pull_request:
     branches:
       - release/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,15 +17,17 @@ on:
 jobs:
   spm_clone:
     runs-on: macos-latest
-    env:
-      BRANCH: ${{env.GITHUB_REF_NAME}}
-    run: |
-          echo "deploying on branch $BRANCH"
-          # Push changes to Swift Engine Toolkit
-          SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
-          git clone $SWIFT_ENGINE_TOOLKIT
-          cd swift-engine-toolkit
-          git checkout $BRANCH || git checkout -b $BRANCH
+    steps:
+      - name: "Clone spm repo"
+        env:
+          BRANCH: ${{env.GITHUB_REF_NAME}}
+        run: |
+              echo "deploying on branch $BRANCH"
+              # Push changes to Swift Engine Toolkit
+              SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
+              git clone $SWIFT_ENGINE_TOOLKIT
+              cd swift-engine-toolkit
+              git checkout $BRANCH || git checkout -b $BRANCH
 
   build:
     needs: [spm_clone]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Branch abd version
         env:
-          BRANCH: ${{env.GITHUB_REF_NAME}}
+          BRANCH: ${{env.GITHUB_REF}}
         run: |
           echo "Branch name: $BRANCH"
-          VERSION=$(cargo pkgid --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | cut -d "#" -f2)
+          VERSION=$(cargo read-manifest --manifest-path ./radix-engine-toolkit-uniffi/Cargo.toml | grep -o '"version": *"[^"]*"' | grep -o '"[^"]*"$')
           echo "Crate version: $VERSION"
 
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
         env:
           BRANCH: ${{env.GITHUB_REF_NAME}}
           GIT_USER: ${{ secrets.RADIX_BOT_USERNAME }}
+          GIT_TOKEN: ${{ secrets.RADIX_BOT_PAT }}
         run: |
               echo "deploying on branch $BRANCH"
               git config user.name $GIT_USER
@@ -30,8 +31,9 @@ jobs:
               # Push changes to Swift Engine Toolkit
               SWIFT_ENGINE_TOOLKIT="https://github.com/radixdlt/swift-engine-toolkit"
               git clone $SWIFT_ENGINE_TOOLKIT
-              cd swift-engine-toolkit
-              git checkout $BRANCH || git checkout -b $BRANCH
+
+              #cd swift-engine-toolkit
+              #git checkout $BRANCH || git checkout -b $BRANCH
 
   build:
     needs: [spm_clone]

--- a/radix-engine-toolkit-uniffi/tests/bindings/example.swift
+++ b/radix-engine-toolkit-uniffi/tests/bindings/example.swift
@@ -3,7 +3,7 @@ import radix_engine_toolkit_uniffi
 
 do {
     // Act
-    let buildInformation = radix_engine_toolkit_uniffi.buildInformation();
+    let buildInformation = radix_engine_toolkit_uniffi.buildInformation()
 
     // Assert
     assert(buildInformation.version == "0.10.0-elm.1")


### PR DESCRIPTION
# Problem Being Solved

Deploy iOS binaries to the swift-engine-toolkit swift package repository.

# Solution
- Updated to create dynamic libraries for all of the target architectures instead of static libs, to greatly reduce the binary size.
- Publish the artefacts - bindings and xcframework - to the swift-engine-toolkit repo, so those can be served as a swift package.
- Added proper versioning and branch handling.