### PR TITLE
Kotlin & Android automatic deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,7 +367,7 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: build publish
           build-root-directory: interop/kotlin/ret-kotlin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -404,7 +404,7 @@ jobs:
       - name: Build and publish Android
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build
+          arguments: build publish
           build-root-directory: interop/android/ret-android
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Create Android Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,6 +376,10 @@ jobs:
           path: artifacts
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v3
+        with:
+          java-version: 1.8
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Create Android Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,7 +400,7 @@ jobs:
         with:
           # The same with interop/android/build.gradle.kts
           gradle-version: 8.0.2
-          arguments: wrapper -p ret-kotlin
+          arguments: wrapper -p ret-android
       - name: Build and publish Android
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -391,7 +391,7 @@ jobs:
       - name: Build and publish Android
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: buildRelease
+          arguments: build
           gradle-executable: interop/android/ret-android
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,7 +368,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-          gradle-executable: interop/kotlin/ret-kotlin
+          build-root-directory: interop/kotlin/ret-kotlin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -405,6 +405,6 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-          gradle-executable: interop/android/ret-android
+          build-root-directory: interop/android/ret-android
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - feature/*
       - develop
       - main
+      - kotlin-deploy
 
 jobs:
   build:
@@ -26,56 +27,56 @@ jobs:
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-apple-darwin
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-apple-ios
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-apple-ios-sim
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-pc-windows-gnu
-            custom-linker: ""
-            custom-compiler: x86_64-w64-mingw32-gcc
-            custom-archiver: x86_64-w64-mingw32-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-unknown-linux-gnu
-            custom-linker: x86_64-unknown-linux-gnu-gcc
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-unknown-linux-gnu
-            custom-linker: aarch64-unknown-linux-gnu-gcc
-            custom-compiler: aarch64-unknown-linux-gnu-gcc
-            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: i686-unknown-linux-gnu
-            custom-linker: i686-unknown-linux-gnu-gcc
-            custom-compiler: i686-unknown-linux-gnu-gcc
-            custom-archiver: i686-unknown-linux-gnu-gcc-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: armv7-linux-androideabi
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: i686-linux-android
-            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: x86_64-apple-darwin
+#            custom-linker: ""
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: aarch64-apple-ios
+#            custom-linker: ""
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: aarch64-apple-ios-sim
+#            custom-linker: ""
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: x86_64-pc-windows-gnu
+#            custom-linker: ""
+#            custom-compiler: x86_64-w64-mingw32-gcc
+#            custom-archiver: x86_64-w64-mingw32-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: x86_64-unknown-linux-gnu
+#            custom-linker: x86_64-unknown-linux-gnu-gcc
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: aarch64-unknown-linux-gnu
+#            custom-linker: aarch64-unknown-linux-gnu-gcc
+#            custom-compiler: aarch64-unknown-linux-gnu-gcc
+#            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: i686-unknown-linux-gnu
+#            custom-linker: i686-unknown-linux-gnu-gcc
+#            custom-compiler: i686-unknown-linux-gnu-gcc
+#            custom-archiver: i686-unknown-linux-gnu-gcc-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: aarch64-linux-android
+#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: armv7-linux-androideabi
+#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: i686-linux-android
+#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
 
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '8'
+          java-version: '11'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Create Android Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
 #            custom-linker: ""
 #            custom-compiler: /usr/local/opt/llvm/bin/clang
 #            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: x86_64-apple-darwin
-#            custom-linker: ""
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-apple-darwin
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
 #          - crate: radix-engine-toolkit-uniffi
 #            target-triple: aarch64-apple-ios
 #            custom-linker: ""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -352,18 +352,21 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artifacts
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
       - name: Create Kotlin Library
         working-directory: interop/kotlin
         run:
           ./bootstrap.sh
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: wrapper -p ret-kotlin
       - name: Build and publish Kotlin
-        working-directory: interop/kotlin/ret-kotlin
-        run:
-          ./gradlew build
-  #        env:
-  #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build
+          gradle-executable: interop/kotlin/ret-kotlin
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-android-maven:
     needs: [ build, create-uniffi-bindings ]
@@ -374,21 +377,21 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artifacts
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          distribution: 'adopt'
+          java-version: '8'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Create Android Library
         working-directory: interop/android
         run:
           ./bootstrap.sh
-      - name: Build and publish Kotlin
-        working-directory: interop/android/ret-android
-        run:
-          ./gradlew build
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and publish Android
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: buildRelease
+          gradle-executable: interop/android/ret-android
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,6 +346,9 @@ jobs:
   publish-kotlin-maven:
     needs: [ build, create-uniffi-bindings ]
     runs-on: macos-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -359,6 +362,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          gradle-version: 8.0.2
           arguments: wrapper -p ret-kotlin
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
@@ -371,6 +375,9 @@ jobs:
   publish-android-maven:
     needs: [ build, create-uniffi-bindings ]
     runs-on: macos-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -388,6 +395,12 @@ jobs:
         working-directory: interop/android
         run:
           ./bootstrap.sh
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          # The same with interop/android/build.gradle.kts
+          gradle-version: 8.0.2
+          arguments: wrapper -p ret-kotlin
       - name: Build and publish Android
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,7 +388,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: '17
+          java-version: '17'
       - name: Setup Android SDK
         uses: android-actions/setup-android@v2
       - name: Create Android Library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,51 +17,51 @@ jobs:
       matrix:
         build-target:
           # radix-engine-toolkit-uniffi Crate
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: aarch64-apple-darwin
-#            custom-linker: ""
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: x86_64-apple-ios
-#            custom-linker: ""
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-apple-darwin
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-apple-ios
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
           - crate: radix-engine-toolkit-uniffi
             target-triple: x86_64-apple-darwin
             custom-linker: ""
             custom-compiler: /usr/local/opt/llvm/bin/clang
             custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: aarch64-apple-ios
-#            custom-linker: ""
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: aarch64-apple-ios-sim
-#            custom-linker: ""
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: x86_64-pc-windows-gnu
-#            custom-linker: ""
-#            custom-compiler: x86_64-w64-mingw32-gcc
-#            custom-archiver: x86_64-w64-mingw32-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: x86_64-unknown-linux-gnu
-#            custom-linker: x86_64-unknown-linux-gnu-gcc
-#            custom-compiler: /usr/local/opt/llvm/bin/clang
-#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: aarch64-unknown-linux-gnu
-#            custom-linker: aarch64-unknown-linux-gnu-gcc
-#            custom-compiler: aarch64-unknown-linux-gnu-gcc
-#            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: i686-unknown-linux-gnu
-#            custom-linker: i686-unknown-linux-gnu-gcc
-#            custom-compiler: i686-unknown-linux-gnu-gcc
-#            custom-archiver: i686-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-apple-ios
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-apple-ios-sim
+            custom-linker: ""
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-pc-windows-gnu
+            custom-linker: ""
+            custom-compiler: x86_64-w64-mingw32-gcc
+            custom-archiver: x86_64-w64-mingw32-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: x86_64-unknown-linux-gnu
+            custom-linker: x86_64-unknown-linux-gnu-gcc
+            custom-compiler: /usr/local/opt/llvm/bin/clang
+            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-unknown-linux-gnu
+            custom-linker: aarch64-unknown-linux-gnu-gcc
+            custom-compiler: aarch64-unknown-linux-gnu-gcc
+            custom-archiver: aarch64-unknown-linux-gnu-gcc-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: i686-unknown-linux-gnu
+            custom-linker: i686-unknown-linux-gnu-gcc
+            custom-compiler: i686-unknown-linux-gnu-gcc
+            custom-archiver: i686-unknown-linux-gnu-gcc-ar
           - crate: radix-engine-toolkit-uniffi
             target-triple: aarch64-linux-android
             custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,6 +376,8 @@ jobs:
           path: artifacts
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
       - name: Create Android Library
         working-directory: interop/android
         run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -363,7 +363,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 8.0.2
-          arguments: wrapper -p ret-kotlin
+          arguments: wrapper -p interop/kotlin/ret-kotlin
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
@@ -400,7 +400,7 @@ jobs:
         with:
           # The same with interop/android/build.gradle.kts
           gradle-version: 8.0.2
-          arguments: wrapper -p ret-android
+          arguments: wrapper -p interop/android/ret-android
       - name: Build and publish Android
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,16 +17,16 @@ jobs:
       matrix:
         build-target:
           # radix-engine-toolkit-uniffi Crate
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: aarch64-apple-darwin
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
-          - crate: radix-engine-toolkit-uniffi
-            target-triple: x86_64-apple-ios
-            custom-linker: ""
-            custom-compiler: /usr/local/opt/llvm/bin/clang
-            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: aarch64-apple-darwin
+#            custom-linker: ""
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
+#          - crate: radix-engine-toolkit-uniffi
+#            target-triple: x86_64-apple-ios
+#            custom-linker: ""
+#            custom-compiler: /usr/local/opt/llvm/bin/clang
+#            custom-archiver: /usr/local/opt/llvm/bin/llvm-ar
 #          - crate: radix-engine-toolkit-uniffi
 #            target-triple: x86_64-apple-darwin
 #            custom-linker: ""
@@ -62,21 +62,21 @@ jobs:
 #            custom-linker: i686-unknown-linux-gnu-gcc
 #            custom-compiler: i686-unknown-linux-gnu-gcc
 #            custom-archiver: i686-unknown-linux-gnu-gcc-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: aarch64-linux-android
-#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
-#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: armv7-linux-androideabi
-#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
-#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
-#          - crate: radix-engine-toolkit-uniffi
-#            target-triple: i686-linux-android
-#            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-#            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
-#            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: aarch64-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: armv7-linux-androideabi
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/armv7a-linux-androideabi19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
+          - crate: radix-engine-toolkit-uniffi
+            target-triple: i686-linux-android
+            custom-linker: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-compiler: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/i686-linux-android19-clang
+            custom-archiver: /usr/local/share/android-ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/llvm-ar
 
     steps:
       - uses: FranzDiebold/github-env-vars-action@v2
@@ -342,3 +342,47 @@ jobs:
         with:
           name: "RadixEngineToolkitUniFFI.xcframework"
           path: "./artifacts/extracted/RadixEngineToolkitUniFFI.xcframework"
+
+  publish-kotlin-maven:
+    needs: [ build, create-uniffi-bindings ]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Create Kotlin Library
+        working-directory: interop/kotlin
+        run:
+          ./bootstrap.sh
+      - name: Build and publish Kotlin
+        working-directory: interop/kotlin/ret-kotlin
+        run:
+          ./gradlew build
+  #        env:
+  #          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-android-maven:
+    needs: [ build, create-uniffi-bindings ]
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+      - name: Create Android Library
+        working-directory: interop/android
+        run:
+          ./bootstrap.sh
+      - name: Build and publish Kotlin
+        working-directory: interop/android/ret-android
+        run:
+          ./gradlew build
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/interop/android/bootstrap.sh
+++ b/interop/android/bootstrap.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+library_name="ret-android"
+src=$library_name/lib/src/main/kotlin
+jni=$library_name/lib/src/main/jniLibs
+package=org/radixdlt/ret
+
+artifacts=../../artifacts
+
+echo "Bootstrap project $library_name"
+mkdir $library_name
+mkdir extracted
+mkdir -p $src/$package
+mkdir -p $jni
+
+# Extracting .kt file
+tar -xzf $artifacts/UniFFI-Bindings/UniFFI-Bindings.tar.gz --directory=extracted
+mv extracted/output/$package/*.kt $src/$package/RET.kt
+
+crate_name=radix-engine-toolkit-uniffi
+jna_architectures=(
+  "arm64-v8a"
+  "armeabi-v7a"
+  "x86"
+)
+ret_names=(
+  "aarch64-linux-android"
+  "armv7-linux-androideabi"
+  "i686-linux-android"
+)
+
+for (( i=0; i<${#jna_architectures[@]}; i++ ));
+do
+  arch_name=${jna_architectures[$i]}
+  ret_name=${ret_names[$i]}
+
+  echo "Extracting for architecture $arch_name"
+
+  mkdir extracted/"$arch_name"
+  tar -xzf $artifacts/"$crate_name"-"$ret_name"/"$ret_name".tar.gz --directory=extracted/"$arch_name"
+  mkdir $jni/"$arch_name"
+  mv extracted/"$arch_name"/*.so $jni/"$arch_name"/libuniffi_radix_engine_toolkit_uniffi.so
+done
+
+rm -rf extracted
+
+# Initialise Gradle project
+cp build.gradle.kts $library_name/build.gradle.kts
+cp settings.gradle.kts $library_name/settings.gradle.kts
+cp lib.build.gradle.kts $library_name/lib/build.gradle.kts
+
+# Extract version from Cargo.toml
+toml=../../radix-engine-toolkit-uniffi/Cargo.toml
+ret_version=$(grep -m 1 version $toml | awk -F= '{print $2}' | tr -d '" ')
+commit_hash=$(git rev-parse --short HEAD)
+version="$ret_version-$commit_hash"
+echo -e "ret-version=$version" >> $library_name/gradle.properties
+
+gradle wrapper -p $library_name

--- a/interop/android/bootstrap.sh
+++ b/interop/android/bootstrap.sh
@@ -55,5 +55,3 @@ ret_version=$(grep -m 1 version $toml | awk -F= '{print $2}' | tr -d '" ')
 commit_hash=$(git rev-parse --short HEAD)
 version="$ret_version-$commit_hash"
 echo -e "ret-version=$version" >> $library_name/gradle.properties
-
-gradle wrapper -p $library_name

--- a/interop/android/build.gradle.kts
+++ b/interop/android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.library") version "8.0.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.7.20" apply false
+}

--- a/interop/android/build.gradle.kts
+++ b/interop/android/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
+    // When updating this version don't forget to update .github/workflows/build.yml publish-android-maven Setup Gradle
     id("com.android.library") version "8.0.2" apply false
     id("org.jetbrains.kotlin.android") version "1.7.20" apply false
 }

--- a/interop/android/lib.build.gradle.kts
+++ b/interop/android/lib.build.gradle.kts
@@ -1,0 +1,51 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+    `maven-publish`
+}
+
+android {
+    namespace = "org.radixdlt.ret"
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 25
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    tasks.withType<KotlinCompile> {
+        kotlinOptions.jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("net.java.dev.jna:jna:5.13.0@aar")
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "org.radixdlt"
+            artifactId = "radix-engine-toolkit-android"
+            version = providers.gradleProperty("ret-version").getOrNull()
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
+}

--- a/interop/android/lib.build.gradle.kts
+++ b/interop/android/lib.build.gradle.kts
@@ -48,4 +48,15 @@ publishing {
             }
         }
     }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/radixdlt/radix-engine-toolkit")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/interop/android/lib.build.gradle.kts
+++ b/interop/android/lib.build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 publishing {
     publications {
         register<MavenPublication>("release") {
-            groupId = "org.radixdlt"
+            groupId = "com.radixdlt"
             artifactId = "radix-engine-toolkit-android"
             version = providers.gradleProperty("ret-version").getOrNull()
 

--- a/interop/android/settings.gradle.kts
+++ b/interop/android/settings.gradle.kts
@@ -1,0 +1,20 @@
+import org.gradle.api.initialization.resolve.RepositoriesMode
+
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "ret-android"
+include("lib")

--- a/interop/kotlin/bootstrap.sh
+++ b/interop/kotlin/bootstrap.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+library_name="ret-kotlin"
+src=$library_name/lib/src/main/kotlin
+res=$library_name/lib/src/main/resources
+package=org/radixdlt/ret
+
+artifacts=../../artifacts
+
+echo "Bootstrap project $library_name"
+mkdir $library_name
+mkdir extracted
+mkdir -p $src/$package
+mkdir -p $res
+
+# Extracting .kt file
+tar -xzf $artifacts/UniFFI-Bindings/UniFFI-Bindings.tar.gz --directory=extracted
+mv extracted/output/$package/*.kt $src/$package/RET.kt
+
+crate_name=radix-engine-toolkit-uniffi
+jna_architectures=(
+  "darwin-aarch64"
+  "darwin-x86-64"
+  "linux-armel"
+  "linux-x86-64"
+  "win32-x86-64"
+)
+ret_names=(
+  "aarch64-apple-darwin"
+  "x86_64-apple-darwin"
+  "aarch64-unknown-linux-gnu"
+  "x86_64-unknown-linux-gnu"
+  "x86_64-pc-windows-gnu"
+)
+suffixes=(
+  "dylib"
+  "dylib"
+  "so"
+  "so"
+  "dll"
+)
+
+for (( i=0; i<${#jna_architectures[@]}; i++ ));
+do
+  arch_name=${jna_architectures[$i]}
+  ret_name=${ret_names[$i]}
+  suffix=${suffixes[$i]}
+
+  echo "Extracting for architecture $arch_name"
+
+  mkdir extracted/"$arch_name"
+  tar -xzf $artifacts/"$crate_name"-"$ret_name"/"$ret_name".tar.gz --directory=extracted/"$arch_name"
+  mkdir $res/"$arch_name"
+  mv extracted/"$arch_name"/*."$suffix" $res/"$arch_name"/libuniffi_radix_engine_toolkit_uniffi."$suffix"
+done
+
+rm -rf extracted
+
+# Initialise Gradle project
+cp build.gradle.kts $library_name/lib/build.gradle.kts
+cp settings.gradle.kts $library_name/settings.gradle.kts
+
+# Extract version from Cargo.toml
+toml=../../radix-engine-toolkit-uniffi/Cargo.toml
+ret_version=$(grep -m 1 version $toml | awk -F= '{print $2}' | tr -d '" ')
+commit_hash=$(git rev-parse --short HEAD)
+version="$ret_version-$commit_hash"
+echo -e "ret-version=$version" >> $library_name/gradle.properties
+
+gradle wrapper -p $library_name

--- a/interop/kotlin/bootstrap.sh
+++ b/interop/kotlin/bootstrap.sh
@@ -66,5 +66,3 @@ ret_version=$(grep -m 1 version $toml | awk -F= '{print $2}' | tr -d '" ')
 commit_hash=$(git rev-parse --short HEAD)
 version="$ret_version-$commit_hash"
 echo -e "ret-version=$version" >> $library_name/gradle.properties
-
-gradle wrapper -p $library_name

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.gradle.jvm.tasks.Jar
+
+plugins {
+    kotlin("jvm") version "1.8.21"
+    `java-library`
+    `maven-publish`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+   implementation("net.java.dev.jna:jna:5.13.0")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = "org.radixdlt"
+            artifactId = "radix-engine-toolkit-kotlin"
+            version = providers.gradleProperty("ret-version").getOrNull()
+
+            from(components["java"])
+        }
+    }
+}

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -30,4 +30,15 @@ publishing {
             from(components["java"])
         }
     }
+
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/radixdlt/radix-engine-toolkit")
+            credentials {
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+    }
 }

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -23,7 +23,7 @@ java {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            groupId = "org.radixdlt"
+            groupId = "com.radixdlt"
             artifactId = "radix-engine-toolkit-kotlin"
             version = providers.gradleProperty("ret-version").getOrNull()
 

--- a/interop/kotlin/settings.gradle.kts
+++ b/interop/kotlin/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "ret-kotlin"
+include("lib")


### PR DESCRIPTION
# Problem Being Solved

Automatically creating Kotlin and Android libraries in CI. These libraries are published to Github's Packages (as they are currently internal to the organisation)

# Solution

## Build
1. Kotlin:
   This is a simple `jar` that contains binaries with compatibility to the below architectures
   
    | Architectures |
    |--------|
    | `darwin-aarch64` |
    | `darwin-x86-64` |
    | `linux-armel` |
    | `linux-x86-64` |
    | `win32-x86-64` | 
    
2. Android
    This is an `.aar` library that contains binaries with compatibility to the below architectures

    | Architectures |
    |--------|
    | `arm64-v8a` |
    | `armeabi-v7a` |
    | `x86` |

Both targets, use the Gradle build system to package and build the libraries. Both of them need to depend on
`net.java.dev.jna:jna:5.13.0` in order to compile. The reason that there is a separate library for android is that in order for android to include the necessary `.so` files alongside jna the dependency needs an `@aar` suffix at the end. 

## Versioning
Both targets will reuse the same version defined in `radix-engine-toolkit-uniffi/Cargo.toml` by suffixing the commit hash in the end like `0.10.0-elm.1-c36f219`

The resulting artifact urls are:
```
// For Kotlin
com.radixdlt:radix-engine-toolkit-kotlin:<version>

// For Android
com.radixdlt:radix-engine-toolkit-android:<version>
```

# Recommended Review Path

`interop/kotlin` & `interop/android` directories contain the gradle scripts that are being used in the resulting "auto-generated" projects. 

There are two `bootstrap.sh` scripts for each target that handle unpacking and copying the binaries to the correct place.