### PR TITLE
publish artifacts to maven central

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,8 +414,11 @@ jobs:
           gradle-version: 8.0.2
           arguments: wrapper -p interop/kotlin/ret-kotlin
       - name: Get GPG key to sign
+        working-directory: interop/kotlin/ret-kotlin
         run: |
-          aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > interop/kotlin/ret-kotlin/rdx-secring.gpg
+          ls -la
+          aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > rdx-secring.gpg
+          ls -la
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,11 +368,25 @@ jobs:
   publish-kotlin-maven-central:
     needs: [build, generate-uniffi-bindings]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Install AWS CLI
         uses: unfor19/install-aws-cli-action@ee0eb151cf1bca186ccf8c35d314b08d62e0e878 # v1
         with:
           version: 2
+      - name: Checkout actions-oidc-debugger
+        uses: actions/checkout@v3
+        with:
+          repository: github/actions-oidc-debugger
+          ref: main
+          token: ${{ github.token }}
+          path: ./.github/actions/actions-oidc-debugger
+      - name: Debug OIDC Claims
+        uses: ./.github/actions/actions-oidc-debugger
+        with:
+          audience: 'https://github.com/github'
       - name: Configure AWS credentials to fetch secrets
         uses: aws-actions/configure-aws-credentials@97271860067ec931c45b8d104fbf0d15954ab85c # branch v1-node16
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -367,30 +367,30 @@ jobs:
   publish-kotlin-maven-central:
     runs-on: ubuntu-latest
     steps:
-    - name: Install AWS CLI
-      uses: unfor19/install-aws-cli-action@ee0eb151cf1bca186ccf8c35d314b08d62e0e878 # v1
-      with:
-        version: 2
-    - name: Configure AWS credentials to fetch secrets
-      uses: aws-actions/configure-aws-credentials@97271860067ec931c45b8d104fbf0d15954ab85c # branch v1-node16
-      with:
-        role-to-assume: ${{ secrets.AWS_RET_ROLE_NAME }}
-        aws-region: eu-west-2
-        role-session-name: ret-${{ github.run_id }}-${{ github.run_attempt }}
-    - name: Fetch AWS secrets
-      uses: aws-actions/aws-secretsmanager-get-secrets@287592d14d9c9c48199db83dc182ae12af3df18e # v1.0.1
-      with:
-        parse-json-secrets: true
-        secret-ids: |
-          MAVEN_CENTRAL,${{ secrets.MAVEN_CENTRAL_SECRET_ID }},
-          GPG_PASSPHRASE,${{ secrets.GPG_PASSPHRASE_SECRET_ID }}
-    - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
+      - name: Install AWS CLI
+        uses: unfor19/install-aws-cli-action@ee0eb151cf1bca186ccf8c35d314b08d62e0e878 # v1
+        with:
+          version: 2
+      - name: Configure AWS credentials to fetch secrets
+        uses: aws-actions/configure-aws-credentials@97271860067ec931c45b8d104fbf0d15954ab85c # branch v1-node16
+        with:
+          role-to-assume: ${{ secrets.AWS_RET_ROLE_NAME }}
+          aws-region: eu-west-2
+          role-session-name: ret-${{ github.run_id }}-${{ github.run_attempt }}
+      - name: Fetch AWS secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@287592d14d9c9c48199db83dc182ae12af3df18e # v1.0.1
+        with:
+          parse-json-secrets: true
+          secret-ids: |
+            MAVEN_CENTRAL,${{ secrets.MAVEN_CENTRAL_SECRET_ID }},
+            GPG_PASSPHRASE,${{ secrets.GPG_PASSPHRASE_SECRET_ID }}
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v3
         with:
           path: artifacts
       - name: Create Kotlin Library
         working-directory: interop/kotlin
-        run:
+        run: |
           ./bootstrap.sh
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -399,7 +399,7 @@ jobs:
           arguments: wrapper -p interop/kotlin/ret-kotlin
       - name: Get GPG key to sign
         run: |
-           aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > interop/kotlin/ret-kotlin/rdx-secring.gpg
+          aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > interop/kotlin/ret-kotlin/rdx-secring.gpg
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
       - develop
       - main
       - linux-builds-fix
+      - chore/publish-to-maven-central
 jobs:
   build:
     runs-on: ${{ matrix.build-target.runner }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,7 +361,7 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publishToGithubRepository
+          arguments: build publishMavenPublicationToGitHubPackagesRepository
           build-root-directory: interop/kotlin/ret-kotlin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -405,7 +405,7 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publishToMavenCentralRepository -Psigning.secretKeyRingFile=rdx-secring.gpg -Psigning.password=${{ env.GPG_PASSPHRASE_GPG_PASSPHRASE }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -PossrhUsername=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_USERNAME }} -PossrhPassword=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_PASSWORD }}
+          arguments: build publishMavenPublicationToMavenCentralRepository -Psigning.secretKeyRingFile=rdx-secring.gpg -Psigning.password=${{ env.GPG_PASSPHRASE_GPG_PASSPHRASE }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -PossrhUsername=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_USERNAME }} -PossrhPassword=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_PASSWORD }}
           build-root-directory: interop/kotlin/ret-kotlin
   publish-android-maven:
     needs: [build, generate-uniffi-bindings]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -361,7 +361,7 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publishMavenPublicationToGitHubPackagesRepository
+          arguments: build publishMavenGithubPublicationToGitHubPackagesRepository
           build-root-directory: interop/kotlin/ret-kotlin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -405,7 +405,7 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publishMavenPublicationToMavenCentralRepository -Psigning.secretKeyRingFile=rdx-secring.gpg -Psigning.password=${{ env.GPG_PASSPHRASE_GPG_PASSPHRASE }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -PossrhUsername=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_USERNAME }} -PossrhPassword=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_PASSWORD }}
+          arguments: build publishMavenCentralPublicationToMavenCentralRepository -Psigning.secretKeyRingFile=rdx-secring.gpg -Psigning.password=${{ env.GPG_PASSPHRASE_GPG_PASSPHRASE }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -PossrhUsername=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_USERNAME }} -PossrhPassword=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_PASSWORD }}
           build-root-directory: interop/kotlin/ret-kotlin
   publish-android-maven:
     needs: [build, generate-uniffi-bindings]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,6 +366,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   publish-kotlin-maven-central:
+    needs: [build, generate-uniffi-bindings]
     runs-on: ubuntu-latest
     steps:
       - name: Install AWS CLI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,11 +414,13 @@ jobs:
           gradle-version: 8.0.2
           arguments: wrapper -p interop/kotlin/ret-kotlin
       - name: Get GPG key to sign
-        working-directory: interop/kotlin/ret-kotlin
+        working-directory: interop/kotlin/ret-kotlin/lib
         run: |
           ls -la
           aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > rdx-secring.gpg
+          cp rdx-secring.gpg lib/rdx-secring.gpg
           ls -la
+          ls -la lib
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,7 @@ jobs:
         with:
           name: "RadixEngineToolkit.xcframework"
           path: "./artifacts/RadixEngineToolkit.xcframework"
-  publish-kotlin-maven:
+  publish-kotlin-maven-github:
     needs: [build, generate-uniffi-bindings]
     runs-on: macos-latest
     permissions:
@@ -360,10 +360,51 @@ jobs:
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publish
+          arguments: build publishToGithubRepository
           build-root-directory: interop/kotlin/ret-kotlin
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  publish-kotlin-maven-central:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install AWS CLI
+      uses: unfor19/install-aws-cli-action@ee0eb151cf1bca186ccf8c35d314b08d62e0e878 # v1
+      with:
+        version: 2
+    - name: Configure AWS credentials to fetch secrets
+      uses: aws-actions/configure-aws-credentials@97271860067ec931c45b8d104fbf0d15954ab85c # branch v1-node16
+      with:
+        role-to-assume: ${{ secrets.AWS_RET_ROLE_NAME }}
+        aws-region: eu-west-2
+        role-session-name: ret-${{ github.run_id }}-${{ github.run_attempt }}
+    - name: Fetch AWS secrets
+      uses: aws-actions/aws-secretsmanager-get-secrets@287592d14d9c9c48199db83dc182ae12af3df18e # v1.0.1
+      with:
+        parse-json-secrets: true
+        secret-ids: |
+          MAVEN_CENTRAL,${{ secrets.MAVEN_CENTRAL_SECRET_ID }},
+          GPG_PASSPHRASE,${{ secrets.GPG_PASSPHRASE_SECRET_ID }}
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v3
+        with:
+          path: artifacts
+      - name: Create Kotlin Library
+        working-directory: interop/kotlin
+        run:
+          ./bootstrap.sh
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 8.0.2
+          arguments: wrapper -p interop/kotlin/ret-kotlin
+      - name: Get GPG key to sign
+        run: |
+           aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > interop/kotlin/ret-kotlin/rdx-secring.gpg
+      - name: Build and publish Kotlin
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: build publishToMavenCentralRepository -Psigning.secretKeyRingFile=rdx-secring.gpg -Psigning.password=${{ env.GPG_PASSPHRASE_GPG_PASSPHRASE }} -Psigning.keyId=${{ secrets.GPG_KEY_ID }} -PossrhUsername=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_USERNAME }} -PossrhPassword=${{ env.MAVEN_CENTRAL_MAVEN_CENTRAL_PASSWORD }}
+          build-root-directory: interop/kotlin/ret-kotlin
   publish-android-maven:
     needs: [build, generate-uniffi-bindings]
     runs-on: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -414,7 +414,7 @@ jobs:
           gradle-version: 8.0.2
           arguments: wrapper -p interop/kotlin/ret-kotlin
       - name: Get GPG key to sign
-        working-directory: interop/kotlin/ret-kotlin/lib
+        working-directory: interop/kotlin/ret-kotlin
         run: |
           ls -la
           aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > rdx-secring.gpg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
       - develop
       - main
       - linux-builds-fix
-      - chore/publish-to-maven-central
 jobs:
   build:
     runs-on: ${{ matrix.build-target.runner }}
@@ -416,11 +415,8 @@ jobs:
       - name: Get GPG key to sign
         working-directory: interop/kotlin/ret-kotlin
         run: |
-          ls -la
           aws secretsmanager get-secret-value --secret-id ${{ secrets.GPG_BINARY_SECRET_ID }}  --query SecretBinary --output text | base64 --decode > rdx-secring.gpg
           cp rdx-secring.gpg lib/rdx-secring.gpg
-          ls -la
-          ls -la lib
       - name: Build and publish Kotlin
         uses: gradle/gradle-build-action@v2
         with:

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -23,7 +23,14 @@ java {
 
 publishing {
     publications {
-        create<MavenPublication>("maven") {
+        create<MavenPublication>("mavenGithub") {
+            groupId = "com.radixdlt"
+            artifactId = "radix-engine-toolkit-kotlin"
+            version = providers.gradleProperty("ret-version").getOrNull()
+
+            from(components["java"])
+        }
+        create<MavenPublication>("mavenCentral") {
             groupId = "com.radixdlt"
             artifactId = "radix-engine-toolkit-kotlin"
             version = providers.gradleProperty("ret-version").getOrNull()
@@ -43,7 +50,7 @@ publishing {
         }
 
         maven {
-            name = "MavenCentral"
+            name = "mavenCentral"
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
             credentials {
                 username = project.findProperty("ossrhUsername") as String?
@@ -54,5 +61,5 @@ publishing {
 }
 
 signing {
-    sign(publishing.publications["maven"])
+    sign(publishing.publications["mavenCentral"])
 }

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     kotlin("jvm") version "1.8.21"
     `java-library`
     `maven-publish`
+    `signing`
 }
 
 repositories {
@@ -40,5 +41,17 @@ publishing {
                 password = System.getenv("GITHUB_TOKEN")
             }
         }
+
+        maven {
+            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            credentials {
+                username = project.findProperty("ossrhUsername") as String?
+                password = project.findProperty("ossrhPassword") as String?
+            }
+        }
     }
+}
+
+signing {
+    sign(publishing.publications["maven"])
 }

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -43,6 +43,7 @@ publishing {
         }
 
         maven {
+            name = "MavenCentral"
             url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
             credentials {
                 username = project.findProperty("ossrhUsername") as String?

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -36,6 +36,13 @@ publishing {
             version = providers.gradleProperty("ret-version").getOrNull()
 
             from(components["java"])
+
+            licenses {
+                license {
+                    name = "Apache License, Version 2.0"
+                    url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+                }
+            }
         }
     }
 

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -51,7 +51,7 @@ publishing {
 
         maven {
             name = "mavenCentral"
-            url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
             credentials {
                 username = project.findProperty("ossrhUsername") as String?
                 password = project.findProperty("ossrhPassword") as String?

--- a/interop/kotlin/build.gradle.kts
+++ b/interop/kotlin/build.gradle.kts
@@ -43,6 +43,13 @@ publishing {
                     url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
                 }
             }
+
+            pom.withXml {
+                def licensesNode = asNode().appendNode('licenses')
+                def licenseNode = licensesNode.appendNode('license')
+                licenseNode.appendNode('name', 'Radix Eula')
+                licenseNode.appendNode('url', 'https://www.radixdlt.com/terms/genericEULA')
+            }
         }
     }
 


### PR DESCRIPTION
kotlin libs will be published to both maven central and github artifacts. 
Maven central publications are signed with the GPG key while the github artifacts are not signed