### PR TITLE
Bugfix for swift uniffiCheckCallStatus() error canceled

### DIFF
--- a/crates/radix-engine-toolkit-uniffi/Cargo.toml
+++ b/crates/radix-engine-toolkit-uniffi/Cargo.toml
@@ -18,18 +18,18 @@ radix-engine-interface = { workspace = true }
 radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["cli"] }
+uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", branch = "bugfix/result-type-in-lower-return", features = ["cli"] }
 hex = "0.4.3"
 thiserror = "1.0.50"
 paste = "1.0.12"
 
 [build-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["build"] }
+uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", branch = "bugfix/result-type-in-lower-return", features = ["build"] }
 
 [dev-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", branch = "bugfix/result-type-in-lower-return", features = ["bindgen-tests"] }
 scrypto-unit = { workspace = true }
 radix-engine-stores = { workspace = true }
 transaction-scenarios = { workspace = true }

--- a/crates/radix-engine-toolkit-uniffi/Cargo.toml
+++ b/crates/radix-engine-toolkit-uniffi/Cargo.toml
@@ -18,18 +18,18 @@ radix-engine-interface = { workspace = true }
 radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["cli"] }
 hex = "0.4.3"
-thiserror = "1.0.40"
+thiserror = "1.0.50"
 paste = "1.0.12"
 
 [build-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["build"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["build"] }
 
 [dev-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["bindgen-tests"] }
 scrypto-unit = { workspace = true }
 radix-engine-stores = { workspace = true }
 transaction-scenarios = { workspace = true }

--- a/crates/radix-engine-toolkit-uniffi/Cargo.toml
+++ b/crates/radix-engine-toolkit-uniffi/Cargo.toml
@@ -18,18 +18,18 @@ radix-engine-interface = { workspace = true }
 radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", tag = "v0.25.2", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["cli"] }
 hex = "0.4.3"
 thiserror = "1.0.40"
 paste = "1.0.12"
 
 [build-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", tag = "v0.25.2", features = ["build"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["build"] }
 
 [dev-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", tag = "v0.25.2", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["bindgen-tests"] }
 scrypto-unit = { workspace = true }
 radix-engine-stores = { workspace = true }
 transaction-scenarios = { workspace = true }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.3"
 edition = "2021"
 
 [dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", tag = "v0.25.2", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["cli"] }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.3"
 edition = "2021"
 
 [dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["cli"] }
+uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", branch = "bugfix/result-type-in-lower-return", features = ["cli"] }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.3"
 edition = "2021"
 
 [dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", branch = "main", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev="8ace8047e569d688e5a06b198240970960666138", features = ["cli"] }


### PR DESCRIPTION
# Summary
Fixed bug in generated swift `uniffiCheckCallStatus` function.

# Details
`uniffi-rs` generates `uniffiCheckCallStatus()` swift function which trows error canceled which is supported from iOS v13.
`radix-engine-toolkit` supports iOS from version 11, so error canceled is not supported and causes unsuccessful iOS projects build.
Solution was provided on Nov 3 by `uniffi-rs` project, so we are switching to use latest `main` branch of this dependency.
Unfortunately there is a bug in `uniffi-rs` which prevents use it directly, so fork has been created and fix for `uniffi-rs`: https://github.com/mstrug-rdx/uniffi-rs/tree/bugfix/result-type-in-lower-return, which will be submitted to `uniffi-rs` project as bugfix.

# Testing
I did a verification of created swift uniffi binding `uniffiCheckCallStatus()` function, `CALL_CANCELLED` case is not throwing error anymore, it calls `fatalError()` function (file: /radix-engine-toolkit/crates/radix-engine-toolkit-uniffi/output/radix_engine_toolkit_uniffi.swift).