### PR TITLE
Switched uniffi-rs repo back to mozilla

### DIFF
--- a/crates/radix-engine-toolkit-uniffi/Cargo.toml
+++ b/crates/radix-engine-toolkit-uniffi/Cargo.toml
@@ -18,18 +18,18 @@ radix-engine-interface = { workspace = true }
 radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "68b14c95a653b8da3a57b8417d1142bd190eac38", features = ["cli"] }
 hex = "0.4.3"
 thiserror = "1.0.50"
 paste = "1.0.12"
 
 [build-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["build"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "68b14c95a653b8da3a57b8417d1142bd190eac38", features = ["build"] }
 
 [dev-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "68b14c95a653b8da3a57b8417d1142bd190eac38", features = ["bindgen-tests"] }
 scrypto-unit = { workspace = true }
 radix-engine-stores = { workspace = true }
 transaction-scenarios = { workspace = true }

--- a/crates/radix-engine-toolkit-uniffi/Cargo.toml
+++ b/crates/radix-engine-toolkit-uniffi/Cargo.toml
@@ -18,18 +18,18 @@ radix-engine-interface = { workspace = true }
 radix-engine-toolkit = { path = "../radix-engine-toolkit" }
 
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", rev = "2c6b351cc2ef11c16eff161f43b14f0fab8fd4f3", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["cli"] }
 hex = "0.4.3"
 thiserror = "1.0.50"
 paste = "1.0.12"
 
 [build-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", rev = "2c6b351cc2ef11c16eff161f43b14f0fab8fd4f3", features = ["build"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["build"] }
 
 [dev-dependencies]
 # The UniFFI crate for generating bindings to other languages
-uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", rev = "2c6b351cc2ef11c16eff161f43b14f0fab8fd4f3", features = ["bindgen-tests"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["bindgen-tests"] }
 scrypto-unit = { workspace = true }
 radix-engine-stores = { workspace = true }
 transaction-scenarios = { workspace = true }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.3"
 edition = "2021"
 
 [dependencies]
-uniffi = { git = "https://github.com/mstrug-rdx/uniffi-rs/", rev = "2c6b351cc2ef11c16eff161f43b14f0fab8fd4f3", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["cli"] }

--- a/crates/uniffi-bindgen/Cargo.toml
+++ b/crates/uniffi-bindgen/Cargo.toml
@@ -4,4 +4,4 @@ version = "1.0.3"
 edition = "2021"
 
 [dependencies]
-uniffi = { git = "https://github.com/mozilla/uniffi-rs/", features = ["cli"] }
+uniffi = { git = "https://github.com/mozilla/uniffi-rs/", rev = "68b14c95a653b8da3a57b8417d1142bd190eac38", features = ["cli"] }


### PR DESCRIPTION
# Summary
Switched uniffi-rs repo back to mozilla.

# Details
PR related to: https://github.com/radixdlt/radix-engine-toolkit/pull/84

As mozilla already merged proposed fix we can switch back to their repo. Related `uniffi-rs` project PR: https://github.com/mozilla/uniffi-rs/pull/1897
