### PR TITLE
Feature/RET-11 Extend data in returned manifest summary proofs

### DIFF
--- a/crates/radix-engine-toolkit-uniffi/src/transaction/manifest.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/transaction/manifest.rs
@@ -701,7 +701,7 @@ impl DetailedManifestClass {
 pub struct ExecutionSummary {
     pub account_withdraws: HashMap<String, Vec<ResourceIndicator>>,
     pub account_deposits: HashMap<String, Vec<ResourceIndicator>>,
-    pub presented_proofs: HashMap<Arc<Address>, Vec<ResourceSpecifier>>,
+    pub presented_proofs: HashMap<String, Vec<ResourceSpecifier>>,
     pub new_entities: NewEntities,
     pub encountered_entities: Vec<Arc<Address>>,
     pub accounts_requiring_auth: Vec<Arc<Address>>,
@@ -754,10 +754,11 @@ impl ExecutionSummary {
                 .into_iter()
                 .map(|item| {
                     (
-                        Arc::new(Address::unsafe_from_raw(
+                        Address::unsafe_from_raw(
                             item.0.into_node_id(),
                             network_id,
-                        )),
+                        )
+                        .address_string(),
                         item.1
                             .iter()
                             .map(|i| {
@@ -834,7 +835,7 @@ impl ExecutionSummary {
 
 #[derive(Clone, Debug, Record)]
 pub struct ManifestSummary {
-    pub presented_proofs: HashMap<Arc<Address>, Vec<ResourceSpecifier>>,
+    pub presented_proofs: HashMap<String, Vec<ResourceSpecifier>>,
     pub accounts_withdrawn_from: Vec<Arc<Address>>,
     pub accounts_deposited_into: Vec<Arc<Address>>,
     pub encountered_entities: Vec<Arc<Address>>,
@@ -852,10 +853,11 @@ impl ManifestSummary {
                 .into_iter()
                 .map(|item| {
                     (
-                        Arc::new(Address::unsafe_from_raw(
+                        Address::unsafe_from_raw(
                             item.0.into_node_id(),
                             network_id,
-                        )),
+                        )
+                        .address_string(),
                         item.1
                             .iter()
                             .map(|i| {

--- a/crates/radix-engine-toolkit-uniffi/src/transaction/manifest.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/transaction/manifest.rs
@@ -701,7 +701,7 @@ impl DetailedManifestClass {
 pub struct ExecutionSummary {
     pub account_withdraws: HashMap<String, Vec<ResourceIndicator>>,
     pub account_deposits: HashMap<String, Vec<ResourceIndicator>>,
-    pub presented_proofs: Vec<Arc<Address>>,
+    pub presented_proofs: HashMap<Arc<Address>, Vec<ResourceSpecifier>>,
     pub new_entities: NewEntities,
     pub encountered_entities: Vec<Arc<Address>>,
     pub accounts_requiring_auth: Vec<Arc<Address>>,
@@ -753,10 +753,18 @@ impl ExecutionSummary {
                 .presented_proofs
                 .into_iter()
                 .map(|item| {
-                    Arc::new(Address::unsafe_from_raw(
-                        item.into_node_id(),
-                        network_id,
-                    ))
+                    (
+                        Arc::new(Address::unsafe_from_raw(
+                            item.0.into_node_id(),
+                            network_id,
+                        )),
+                        item.1
+                            .iter()
+                            .map(|i| {
+                                ResourceSpecifier::from_native(i, network_id)
+                            })
+                            .collect(),
+                    )
                 })
                 .collect(),
             new_entities: NewEntities::from_native(
@@ -826,7 +834,7 @@ impl ExecutionSummary {
 
 #[derive(Clone, Debug, Record)]
 pub struct ManifestSummary {
-    pub presented_proofs: Vec<Arc<Address>>,
+    pub presented_proofs: HashMap<Arc<Address>, Vec<ResourceSpecifier>>,
     pub accounts_withdrawn_from: Vec<Arc<Address>>,
     pub accounts_deposited_into: Vec<Arc<Address>>,
     pub encountered_entities: Vec<Arc<Address>>,
@@ -843,10 +851,18 @@ impl ManifestSummary {
                 .presented_proofs
                 .into_iter()
                 .map(|item| {
-                    Arc::new(Address::unsafe_from_raw(
-                        item.into_node_id(),
-                        network_id,
-                    ))
+                    (
+                        Arc::new(Address::unsafe_from_raw(
+                            item.0.into_node_id(),
+                            network_id,
+                        )),
+                        item.1
+                            .iter()
+                            .map(|i| {
+                                ResourceSpecifier::from_native(i, network_id)
+                            })
+                            .collect(),
+                    )
                 })
                 .collect(),
             accounts_withdrawn_from: native

--- a/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
@@ -52,9 +52,7 @@ impl ManifestSummaryCallback for PresentedProofsDetector {
                             {
                                 item[idx] = ResourceSpecifier::Amount(
                                     *address,
-                                    amount
-                                        .checked_add(*new_amount)
-                                        .expect("Overflow"),
+                                    *amount.max(new_amount),
                                 )
                             }
                         }

--- a/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
@@ -39,38 +39,7 @@ impl ManifestSummaryCallback for PresentedProofsDetector {
     ) {
         self.presented_proofs
             .entry(*account)
-            .and_modify(|item| {
-                if let Some((idx, res)) =
-                    item.iter().enumerate().find(|(_, res)| {
-                        res.resource_address() == resource.resource_address()
-                    })
-                {
-                    match res {
-                        ResourceSpecifier::Amount(address, amount) => {
-                            if let ResourceSpecifier::Amount(_, new_amount) =
-                                resource
-                            {
-                                item[idx] = ResourceSpecifier::Amount(
-                                    *address,
-                                    *amount.max(new_amount),
-                                )
-                            }
-                        }
-                        ResourceSpecifier::Ids(address, ids) => {
-                            if let ResourceSpecifier::Ids(_, ids_to_add) =
-                                resource
-                            {
-                                let mut new_ids = ids.clone();
-                                new_ids.extend(ids_to_add.clone());
-                                item[idx] =
-                                    ResourceSpecifier::Ids(*address, new_ids);
-                            }
-                        }
-                    }
-                } else {
-                    item.push(resource.clone());
-                }
-            })
+            .and_modify(|res_vector| res_vector.push(resource.clone()))
             .or_insert(vec![resource.clone()]);
     }
 }

--- a/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/traverser/auxiliary/presented_proofs.rs
@@ -15,24 +15,54 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use radix_engine::system::system_modules::execution_trace::*;
 use scrypto::prelude::*;
 
 use crate::transaction_types::*;
 
 #[derive(Default)]
 pub struct PresentedProofsDetector {
-    presented_proofs: IndexSet<ResourceAddress>,
+    presented_proofs: IndexMap<ComponentAddress, Vec<ResourceSpecifier>>,
 }
 
 impl PresentedProofsDetector {
-    pub fn output(self) -> IndexSet<ResourceAddress> {
+    pub fn output(self) -> IndexMap<ComponentAddress, Vec<ResourceSpecifier>> {
         self.presented_proofs
     }
 }
 
 impl ManifestSummaryCallback for PresentedProofsDetector {
-    fn on_create_proof(&mut self, resource_address: &ResourceAddress) {
-        self.presented_proofs.insert(*resource_address);
+    fn on_create_proof(
+        &mut self,
+        account: &ComponentAddress,
+        resource: &ResourceSpecifier,
+    ) {
+        self.presented_proofs.entry(*account).and_modify(|item| {
+            if let Some(res) = item.iter().find(|res| {
+                res.resource_address() == resource.resource_address()
+            }) {
+                match res {
+                    ResourceSpecifier::Amount(_, mut amount) => {
+                        match resource {
+                            ResourceSpecifier::Amount(_, new_amount) => {
+                                amount = amount
+                                    .checked_add(*new_amount)
+                                    .expect("Overflow");
+                            }
+                            ResourceSpecifier::Ids(_, _) => (),
+                        }
+                    }
+                    ResourceSpecifier::Ids(_, mut ids) => match resource {
+                        ResourceSpecifier::Amount(_, _) => (),
+                        ResourceSpecifier::Ids(_, new_ids) => {
+                            ids.extend(new_ids.clone());
+                        }
+                    },
+                }
+            } else {
+                item.push(resource.clone());
+            }
+        });
     }
 }
 

--- a/crates/radix-engine-toolkit/src/transaction_types/traverser/traits.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/traverser/traits.rs
@@ -36,7 +36,12 @@ pub trait ManifestSummaryCallback {
 
     /// Called when a proof is created out of an account.
     #[inline]
-    fn on_create_proof(&mut self, _resource_address: &ResourceAddress) {}
+    fn on_create_proof(
+        &mut self,
+        _account: &ComponentAddress,
+        _resource: &ResourceSpecifier,
+    ) {
+    }
 
     /// Called when a global entity is encountered in the manifest
     #[inline]

--- a/crates/radix-engine-toolkit/src/transaction_types/types.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/types.rs
@@ -33,7 +33,7 @@ use super::*;
 /// A summary of the manifest
 #[derive(Clone, Debug)]
 pub struct ManifestSummary {
-    /// The set of the resources of proofs that were presented in the manifest.
+    /// The list of the resources of proofs that were presented in the manifest.
     pub presented_proofs: IndexMap<ComponentAddress, Vec<ResourceSpecifier>>,
     /// The set of accounts withdrawn from observed in the manifest.
     pub accounts_withdrawn_from: IndexSet<ComponentAddress>,
@@ -64,8 +64,7 @@ pub struct ExecutionSummary {
     pub account_withdraws: IndexMap<ComponentAddress, Vec<ResourceIndicator>>,
     /// The deposits done in the manifest.
     pub account_deposits: IndexMap<ComponentAddress, Vec<ResourceIndicator>>,
-    /// The set of the resource addresses of proofs that were presented in
-    /// the manifest.
+    /// The list of the resources of proofs that were presented in the manifest.
     pub presented_proofs: IndexMap<ComponentAddress, Vec<ResourceSpecifier>>,
     /// Information on the global entities created in the transaction.
     pub new_entities: NewEntities,

--- a/crates/radix-engine-toolkit/src/transaction_types/types.rs
+++ b/crates/radix-engine-toolkit/src/transaction_types/types.rs
@@ -33,9 +33,8 @@ use super::*;
 /// A summary of the manifest
 #[derive(Clone, Debug)]
 pub struct ManifestSummary {
-    /// The set of the resource addresses of proofs that were presented in
-    /// the manifest.
-    pub presented_proofs: IndexSet<ResourceAddress>,
+    /// The set of the resources of proofs that were presented in the manifest.
+    pub presented_proofs: IndexMap<ComponentAddress, Vec<ResourceSpecifier>>,
     /// The set of accounts withdrawn from observed in the manifest.
     pub accounts_withdrawn_from: IndexSet<ComponentAddress>,
     /// The set of accounts deposited into observed in the manifest.
@@ -67,7 +66,7 @@ pub struct ExecutionSummary {
     pub account_deposits: IndexMap<ComponentAddress, Vec<ResourceIndicator>>,
     /// The set of the resource addresses of proofs that were presented in
     /// the manifest.
-    pub presented_proofs: IndexSet<ResourceAddress>,
+    pub presented_proofs: IndexMap<ComponentAddress, Vec<ResourceSpecifier>>,
     /// Information on the global entities created in the transaction.
     pub new_entities: NewEntities,
     /// The set of all the global entities encountered in the manifest. This is

--- a/crates/radix-engine-toolkit/tests/transaction_types.rs
+++ b/crates/radix-engine-toolkit/tests/transaction_types.rs
@@ -2312,21 +2312,29 @@ fn presented_proofs_fungible() {
     assert_eq!(manifest_summary.presented_proofs.len(), 2);
     let account_1_proofs =
         manifest_summary.presented_proofs.get(&account_1).unwrap();
-    assert_eq!(account_1_proofs.len(), 2);
+    assert_eq!(account_1_proofs.len(), 3);
     assert_eq!(
         account_1_proofs[0],
-        ResourceSpecifier::Amount(address_1, dec!(80))
+        ResourceSpecifier::Amount(address_1, dec!(60))
     );
     assert_eq!(
         account_1_proofs[1],
         ResourceSpecifier::Amount(address_2, dec!(100))
     );
+    assert_eq!(
+        account_1_proofs[2],
+        ResourceSpecifier::Amount(address_1, dec!(80))
+    );
     let account_2_proofs =
         manifest_summary.presented_proofs.get(&account_2).unwrap();
-    assert_eq!(account_2_proofs.len(), 1);
+    assert_eq!(account_2_proofs.len(), 2);
     assert_eq!(
         account_2_proofs[0],
         ResourceSpecifier::Amount(address_3, dec!(30))
+    );
+    assert_eq!(
+        account_2_proofs[1],
+        ResourceSpecifier::Amount(address_3, dec!(5))
     );
 }
 
@@ -2366,6 +2374,14 @@ fn presented_proofs_non_fungible() {
         .create_proof_from_account_of_non_fungibles(
             account_1,
             address_1,
+            [
+                NonFungibleLocalId::integer(1),
+                NonFungibleLocalId::integer(2),
+            ],
+        )
+        .create_proof_from_account_of_non_fungibles(
+            account_2,
+            address_3,
             [NonFungibleLocalId::integer(2)],
         )
         .build();
@@ -2375,16 +2391,12 @@ fn presented_proofs_non_fungible() {
     assert_eq!(manifest_summary.presented_proofs.len(), 2);
     let account_1_proofs =
         manifest_summary.presented_proofs.get(&account_1).unwrap();
-    assert_eq!(account_1_proofs.len(), 2);
+    assert_eq!(account_1_proofs.len(), 3);
     assert_eq!(
         account_1_proofs[0],
         ResourceSpecifier::Ids(
             address_1,
-            [
-                NonFungibleLocalId::integer(1),
-                NonFungibleLocalId::integer(2)
-            ]
-            .into()
+            [NonFungibleLocalId::integer(1)].into()
         )
     );
     assert_eq!(
@@ -2394,9 +2406,20 @@ fn presented_proofs_non_fungible() {
             [NonFungibleLocalId::integer(3)].into()
         )
     );
+    assert_eq!(
+        account_1_proofs[2],
+        ResourceSpecifier::Ids(
+            address_1,
+            [
+                NonFungibleLocalId::integer(1),
+                NonFungibleLocalId::integer(2)
+            ]
+            .into()
+        )
+    );
     let account_2_proofs =
         manifest_summary.presented_proofs.get(&account_2).unwrap();
-    assert_eq!(account_2_proofs.len(), 1);
+    assert_eq!(account_2_proofs.len(), 2);
     assert_eq!(
         account_2_proofs[0],
         ResourceSpecifier::Ids(
@@ -2406,6 +2429,13 @@ fn presented_proofs_non_fungible() {
                 NonFungibleLocalId::integer(3)
             ]
             .into()
+        )
+    );
+    assert_eq!(
+        account_2_proofs[01],
+        ResourceSpecifier::Ids(
+            address_3,
+            [NonFungibleLocalId::integer(2)].into()
         )
     );
 }

--- a/crates/radix-engine-toolkit/tests/transaction_types.rs
+++ b/crates/radix-engine-toolkit/tests/transaction_types.rs
@@ -2359,8 +2359,8 @@ fn presented_proofs_non_fungible() {
             account_2,
             address_3,
             [
-                NonFungibleLocalId::integer(1),
                 NonFungibleLocalId::integer(2),
+                NonFungibleLocalId::integer(3),
             ],
         )
         .create_proof_from_account_of_non_fungibles(
@@ -2402,8 +2402,8 @@ fn presented_proofs_non_fungible() {
         ResourceSpecifier::Ids(
             address_3,
             [
-                NonFungibleLocalId::integer(1),
-                NonFungibleLocalId::integer(2)
+                NonFungibleLocalId::integer(2),
+                NonFungibleLocalId::integer(3)
             ]
             .into()
         )

--- a/crates/radix-engine-toolkit/tests/transaction_types.rs
+++ b/crates/radix-engine-toolkit/tests/transaction_types.rs
@@ -2300,10 +2300,10 @@ fn presented_proofs_fungible() {
     //Act
     let manifest = ManifestBuilder::new()
         .lock_fee_from_faucet()
-        .create_proof_from_account_of_amount(account_1, address_1, 1)
+        .create_proof_from_account_of_amount(account_1, address_1, 60)
         .create_proof_from_account_of_amount(account_2, address_3, 30)
         .create_proof_from_account_of_amount(account_1, address_2, 100)
-        .create_proof_from_account_of_amount(account_1, address_1, 2)
+        .create_proof_from_account_of_amount(account_1, address_1, 80)
         .create_proof_from_account_of_amount(account_2, address_3, 5)
         .build();
     let (manifest_summary, _) = test_runner.summarize(manifest);
@@ -2315,7 +2315,7 @@ fn presented_proofs_fungible() {
     assert_eq!(account_1_proofs.len(), 2);
     assert_eq!(
         account_1_proofs[0],
-        ResourceSpecifier::Amount(address_1, dec!(3))
+        ResourceSpecifier::Amount(address_1, dec!(80))
     );
     assert_eq!(
         account_1_proofs[1],
@@ -2326,7 +2326,7 @@ fn presented_proofs_fungible() {
     assert_eq!(account_2_proofs.len(), 1);
     assert_eq!(
         account_2_proofs[0],
-        ResourceSpecifier::Amount(address_3, dec!(35))
+        ResourceSpecifier::Amount(address_3, dec!(30))
     );
 }
 


### PR DESCRIPTION
## Summary
Extending `ManifestSummary::presented_proofs` field with information regarding account and list of resources used to present as proofs.

## Details
More info here: https://rdxworks.slack.com/archives/C040KJQN5CL/p1706710934790489
Jira task: https://radixdlt.atlassian.net/browse/RET-11

## Testing
Added two new tests.
