### PR TITLE
remove DisplayFromStr for discriminator in enum

### DIFF
--- a/crates/sbor-json/src/scrypto/programmatic/value.rs
+++ b/crates/sbor-json/src/scrypto/programmatic/value.rs
@@ -76,7 +76,6 @@ pub enum ProgrammaticScryptoValue {
     },
     Enum {
         #[serde(rename = "variant_id")]
-        #[serde_as(as = "serde_with::DisplayFromStr")]
         discriminator: u8,
         fields: Vec<ProgrammaticScryptoValue>,
     },


### PR DESCRIPTION
Hi :)

Proposed fix for the following issue:
[Discord message](https://discord.com/channels/417762285172555786/765994894749597697/1221585891575857264)

Take this event as an example:
```json
  "data": {
    "kind": "Enum",
    "type_name": "WithdrawEvent",
    "variant_id": 0,
    "variant_name": "Fungible",
    "fields": [
      {
        "kind": "Reference",
        "type_name": "ResourceAddress",
        "value": "resource_rdx1tknxxxxxxxxxradxrdxxxxxxxxx009923554798xxxxxxxxxradxrd"
      },
      {
        "kind": "Decimal",
        "value": "500.1243461544827"
      }
    ]
  }
```
You can find it here: https://dashboard.radixdlt.com/transaction/txid_rdx1lq7zd5xnl9s2v8rjns4q474jtxjadnesm0u37uyldk6ht3l9kd6sdfedjz/details

The `variant_id` here is 0, as a number, while the toolkit seems to expect it to be a string as per the `#[serde_as(as = "serde_with::DisplayFromStr")]`

I'm not sure whether this is correct and if it has further effects on other code, but this fix worked for me and I need it to work so thought I'd suggest it. Thanks in advance for taking the time.