### PR TITLE
Fix for unsupported type alias in C#

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,7 +514,7 @@ jobs:
       - name: Setup .NET SDK
         uses: RDXWorks-actions/setup-dotnet@5a3fa01c67e60dba8f95e2878436c7151c4b5f01
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
       - name: Configure Version
         run: |
           VERSION=${{ inputs.cs-version }}

--- a/interop/csharp/RadixDlt.RadixEngineToolkit.csproj
+++ b/interop/csharp/RadixDlt.RadixEngineToolkit.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NuspecFile>RadixDlt.RadixEngineToolkit.nuspec</NuspecFile>
-        <LangVersion>11</LangVersion>
+        <LangVersion>12</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/interop/csharp/RadixDlt.RadixEngineToolkit.nuspec
+++ b/interop/csharp/RadixDlt.RadixEngineToolkit.nuspec
@@ -23,6 +23,6 @@
     <!-- Windows Targets -->
     <file src="native/x86_64-pc-windows-gnu/radix_engine_toolkit_uniffi.dll" target="runtimes/win-x64/native/radix_engine_toolkit_uniffi.dll" />
     
-    <file src="bin\Release\net7.0\RadixDlt.RadixEngineToolkit.dll" target="lib\net7.0" />
+    <file src="bin\Release\net8.0\RadixDlt.RadixEngineToolkit.dll" target="lib\net8.0" />
   </files>
 </package>


### PR DESCRIPTION
After adding new type: `HashableBytes` which is represented in uniffi as byte array (`Vec<u8>`) in C# type alias is used for it. Type alias is supported from C# version 12 (.net 8.0). After updating CI build script to use that C# version build works fine.

Successful C# build:
https://github.com/radixdlt/radix-engine-toolkit/actions/runs/8735923494/job/23970334806
