### PR TITLE
Feature/decimal to from bytes

### DIFF
--- a/crates/radix-engine-toolkit-uniffi/src/common/decimal.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/common/decimal.rs
@@ -281,3 +281,33 @@ impl From<crate::prelude::NativeRoundingMode> for RoundingMode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decimal_to_le_bytes() {
+        let d = Decimal::new(String::from("1234567890.123456789")).unwrap();
+        assert_eq!(
+            [
+                0, 146, 124, 189, 145, 122, 121, 109, 235, 53, 253, 3, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0
+            ],
+            d.to_le_bytes().as_slice()
+        );
+    }
+
+    #[test]
+    fn decimal_from_le_bytes() {
+        let d1 = Decimal::new(String::from("1234567890.123456789")).unwrap();
+        let d2 = Decimal::from_le_bytes(
+            &[
+                0, 146, 124, 189, 145, 122, 121, 109, 235, 53, 253, 3, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0,
+            ]
+            .to_vec(),
+        );
+        assert!(d1.equal(d2));
+    }
+}

--- a/crates/radix-engine-toolkit-uniffi/src/common/decimal.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/common/decimal.rs
@@ -22,10 +22,10 @@ use crate::prelude::*;
 macro_rules! define_uniffi_decimal {
     ($type: ty) => {
         paste::paste!{
-            define_uniffi_decimal!{[<$type>],$crate::prelude::[<Native $type>]}
+            define_uniffi_decimal!{[<$type>],$crate::prelude::[<Native $type>],$crate::prelude::[<NativeInner $type>]}
         }
     };
-    ($ident: ident, $native_type: ty) => {
+    ($ident: ident, $native_type: ty, $native_inner_type: ty) => {
         paste::paste! {
             #[derive(Clone, Debug, $crate::prelude::Object, Default)]
             pub struct $ident(pub(crate) $native_type);
@@ -176,6 +176,18 @@ macro_rules! define_uniffi_decimal {
                 pub fn mantissa(&self) -> String {
                     self.0.0.to_string()
                 }
+
+                pub fn to_le_bytes(&self) -> Vec<u8> {
+                    self.0.0.to_le_bytes().to_vec()
+                }
+
+                #[uniffi::constructor]
+                pub fn from_le_bytes(value: &Vec<u8>) -> $crate::prelude::Arc<Self> {
+                    $crate::prelude::Arc::new(Self($native_type($native_inner_type::from_le_bytes(
+                        &value
+                    ))))
+                }
+
             }
         }
     }

--- a/crates/radix-engine-toolkit-uniffi/src/internal_prelude.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/internal_prelude.rs
@@ -233,7 +233,9 @@ mod native {
         hash as native_hash,
 
         Decimal as NativeDecimal,
+        InnerDecimal as NativeInnerDecimal,
         PreciseDecimal as NativePreciseDecimal,
+        InnerPreciseDecimal as NativeInnerPreciseDecimal,
         RoundingMode as NativeRoundingMode,
 
         XRD as NATIVE_XRD,

--- a/crates/radix-engine-toolkit-uniffi/tests/bindings/example_test.go
+++ b/crates/radix-engine-toolkit-uniffi/tests/bindings/example_test.go
@@ -200,3 +200,17 @@ func TestRetPublicKeyFingerprint(t *testing.T) {
 	assert(t, len(converted) == 10, "Length of byte array is invalid")
 	assert(t, reflect.DeepEqual(converted, bytes), "Conversion of byte array failed")
 }
+
+func TestRetDecimalToFromBytes(t *testing.T) {
+	var bytes = []byte{78, 243, 148, 77, 255, 81, 151, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	var dec = "1.123456789012345678"
+
+	var number, err = radix_engine_toolkit_uniffi.NewDecimal(dec)
+	assert(t, err == nil, "New Decimal failed")
+	var bytes_converted = number.ToLeBytes();
+	var converted_back = radix_engine_toolkit_uniffi.DecimalFromLeBytes(bytes_converted)
+
+	assert(t, len(bytes_converted) == 24, "Length of byte array is invalid")
+	assert(t, reflect.DeepEqual(bytes_converted, bytes), "Conversion of byte array failed")
+	assert(t, converted_back.Equal(number), "Conversion of byte array back to Decimal failed")
+}


### PR DESCRIPTION
## Summary
Added conversion from `Decimal` to bytes required in Maya integration.

Requires update to latest Scrypto version (PR https://github.com/radixdlt/radix-engine-toolkit/pull/117)