### PR TITLE
Expose some methods to check what kind of badge a global id is

### DIFF
--- a/crates/radix-engine-toolkit-uniffi/src/common/non_fungible.rs
+++ b/crates/radix-engine-toolkit-uniffi/src/common/non_fungible.rs
@@ -130,6 +130,14 @@ impl NonFungibleGlobalId {
             NativeAddressBech32Encoder::new(&network_definition);
         self.0.to_canonical_string(&bech32_encoder)
     }
+
+    pub fn is_global_caller_badge(&self) -> bool {
+        self.0.resource_address() == NATIVE_GLOBAL_CALLER_RESOURCE
+    }
+
+    pub fn is_package_of_direct_caller_badge(&self) -> bool {
+        self.0.resource_address() == NATIVE_PACKAGE_OF_DIRECT_CALLER_RESOURCE
+    }
 }
 
 #[derive(Clone, Debug, Enum, Hash, PartialEq, Eq)]


### PR DESCRIPTION
The functionality to derive the global caller non-fungible global id and the package caller non-fungible global id is already present in the toolkit. So, this is a small PR that adds a simple getter method for checking if a non-fungible global id badge is either a global or package caller.